### PR TITLE
fix(authentication):`displayName` is missing when signing in with Apple on iOS using `skipNativeAuth`

### DIFF
--- a/.changeset/dull-steaks-count.md
+++ b/.changeset/dull-steaks-count.md
@@ -1,0 +1,5 @@
+---
+"@capacitor-firebase/authentication": patch
+---
+
+fix(ios): `displayName` is missing when signing in with Apple using `skipNativeAuth`

--- a/packages/authentication/ios/Plugin/FirebaseAuthentication.swift
+++ b/packages/authentication/ios/Plugin/FirebaseAuthentication.swift
@@ -261,11 +261,16 @@ public typealias AuthStateChangedObserver = () -> Void
     }
 
     func handleSuccessfulSignIn(credential: AuthCredential, idToken: String?, nonce: String?, accessToken: String?) {
+        self.handleSuccessfulSignIn(credential: credential, idToken: idToken, nonce: nonce, accessToken: accessToken, displayName: nil)
+    }
+
+    func handleSuccessfulSignIn(credential: AuthCredential, idToken: String?, nonce: String?, accessToken: String?, displayName: String?) {
         if config.skipNativeAuth == true {
             guard let savedCall = self.savedCall else {
                 return
             }
-            let result = FirebaseAuthenticationHelper.createSignInResult(credential: credential, user: nil, idToken: idToken, nonce: nonce, accessToken: accessToken, additionalUserInfo: nil)
+            let result = FirebaseAuthenticationHelper.createSignInResult(credential: credential, user: nil, idToken: idToken, nonce: nonce,
+                                                                         accessToken: accessToken, additionalUserInfo: nil, displayName: displayName)
             savedCall.resolve(result)
             return
         }
@@ -278,7 +283,7 @@ public typealias AuthStateChangedObserver = () -> Void
                 return
             }
             let result = FirebaseAuthenticationHelper.createSignInResult(credential: authResult?.credential, user: authResult?.user, idToken: idToken, nonce: nonce, accessToken: accessToken,
-                                                                         additionalUserInfo: authResult?.additionalUserInfo)
+                                                                         additionalUserInfo: authResult?.additionalUserInfo, displayName: displayName)
             savedCall.resolve(result)
         }
     }

--- a/packages/authentication/ios/Plugin/FirebaseAuthenticationHelper.swift
+++ b/packages/authentication/ios/Plugin/FirebaseAuthenticationHelper.swift
@@ -5,7 +5,11 @@ import FirebaseAuth
 
 public class FirebaseAuthenticationHelper {
     public static func createSignInResult(credential: AuthCredential?, user: User?, idToken: String?, nonce: String?, accessToken: String?, additionalUserInfo: AdditionalUserInfo?) -> JSObject {
-        let userResult = self.createUserResult(user)
+        return createSignInResult(credential: credential, user: user, idToken: idToken, nonce: nonce, accessToken: accessToken, additionalUserInfo: additionalUserInfo, displayName: nil)
+    }
+
+    public static func createSignInResult(credential: AuthCredential?, user: User?, idToken: String?, nonce: String?, accessToken: String?, additionalUserInfo: AdditionalUserInfo?, displayName: String?) -> JSObject {
+        let userResult = self.createUserResult(user, displayName: displayName)
         let credentialResult = self.createCredentialResult(credential, idToken: idToken, nonce: nonce, accessToken: accessToken)
         let additionalUserInfoResult = self.createAdditionalUserInfoResult(additionalUserInfo)
         var result = JSObject()
@@ -16,11 +20,15 @@ public class FirebaseAuthenticationHelper {
     }
 
     public static func createUserResult(_ user: User?) -> JSObject? {
+        return createUserResult(user, displayName: nil)
+    }
+
+    public static func createUserResult(_ user: User?, displayName: String?) -> JSObject? {
         guard let user = user else {
             return nil
         }
         var result = JSObject()
-        result["displayName"] = user.displayName
+        result["displayName"] = displayName ?? user.displayName
         result["email"] = user.email
         result["emailVerified"] = user.isEmailVerified
         result["isAnonymous"] = user.isAnonymous

--- a/packages/authentication/ios/Plugin/Handlers/AppleAuthProviderHandler.swift
+++ b/packages/authentication/ios/Plugin/Handlers/AppleAuthProviderHandler.swift
@@ -103,8 +103,14 @@ extension AppleAuthProviderHandler: ASAuthorizationControllerDelegate, ASAuthori
             print("Unable to serialize token string from data: \(appleIDToken.debugDescription)")
             return
         }
+        var displayName: String?
+        if let fullName = appleIDCredential.fullName {
+            if let givenName = fullName.givenName, let familyName = fullName.familyName {
+                displayName = "\(givenName) \(familyName)"
+            }
+        }
         let credential = OAuthProvider.credential(withProviderID: "apple.com", idToken: idTokenString, rawNonce: nonce)
-        self.pluginImplementation.handleSuccessfulSignIn(credential: credential, idToken: idTokenString, nonce: nonce, accessToken: nil)
+        self.pluginImplementation.handleSuccessfulSignIn(credential: credential, idToken: idTokenString, nonce: nonce, accessToken: nil, displayName: displayName)
     }
 
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).

Close #155 