### PR TITLE
fix(messaging): iOS - fix bug where tapping a notification when the app is either in the background or closed, would not trigger any listener

### DIFF
--- a/.changeset/fresh-taxis-admire.md
+++ b/.changeset/fresh-taxis-admire.md
@@ -1,0 +1,5 @@
+---
+"@capacitor-firebase/messaging": patch
+---
+
+fix: issue where tapping a notification on iOS would not trigger the notificationActionPerformed (or any) listener

--- a/packages/messaging/ios/Plugin/FirebaseMessaging.swift
+++ b/packages/messaging/ios/Plugin/FirebaseMessaging.swift
@@ -5,7 +5,7 @@ import UserNotifications
 import FirebaseMessaging
 import FirebaseCore
 
-@objc public class FirebaseMessaging: NSObject, NotificationHandlerProtocol {
+@objc public class FirebaseMessaging: NSObject, NotificationHandlerProtocol, UNUserNotificationCenterDelegate {
     private let plugin: FirebaseMessagingPlugin
     private let config: FirebaseMessagingConfig
 
@@ -16,6 +16,8 @@ import FirebaseCore
         if FirebaseApp.app() == nil {
             FirebaseApp.configure()
         }
+        UNUserNotificationCenter.current().delegate = self
+
         UIApplication.shared.registerForRemoteNotifications()
         Messaging.messaging().delegate = self
         self.plugin.bridge?.notificationRouter.pushNotificationHandler = self
@@ -106,6 +108,24 @@ import FirebaseCore
             Messaging.messaging().appDidReceiveMessage(userInfo)
         }
         self.plugin.handleRemoteNotificationReceived(notification: notification)
+    }
+
+    public func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler:
+        @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([[]])
+    }
+
+    public func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        self.handleNotificationActionPerformed(response: response)
+        completionHandler()
     }
 
     private func handleNotificationReceived(notification: UNNotification) {


### PR DESCRIPTION
One would expect the notificationActionPerformed listener to be called once a notification is tapped on iOS, while the app is in the background or closed. However this does not happen. This PR fixes that.

Tested on iOS 15.4.1.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ x ] The changes have been tested successfully.
- [ x ] A changeset has been created (`npm run changeset`).
