### PR TITLE
refactor: use `getMessage` instead of `getLocalizedMessage` on Android

### DIFF
--- a/.changeset/dull-keys-remain.md
+++ b/.changeset/dull-keys-remain.md
@@ -1,0 +1,12 @@
+---
+"@capacitor-firebase/analytics": major
+"@capacitor-firebase/app": major
+"@capacitor-firebase/app-check": major
+"@capacitor-firebase/authentication": major
+"@capacitor-firebase/crashlytics": major
+"@capacitor-firebase/messaging": major
+"@capacitor-firebase/performance": major
+"@capacitor-firebase/remote-config": major
+---
+
+refactor(android): use `getMessage` instead of `getLocalizedMessage`

--- a/packages/analytics/BREAKING.md
+++ b/packages/analytics/BREAKING.md
@@ -19,6 +19,12 @@ If you want to use this plugin with Capacitor 4, please install version `1.4.0`:
 npm i @capacitor-firebase/analytics@1.4.0
 ```
 
+### Localized error messages
+
+On Android, error messages were previously generated with `getLocalizedMessage`. They are no longer localized and are generated with `getMessage` instead.
+
+You should therefore check your error handling.
+
 ## Version 1.x.x
 
 ### Capacitor 4

--- a/packages/analytics/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/analytics/FirebaseAnalytics.java
+++ b/packages/analytics/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/analytics/FirebaseAnalytics.java
@@ -26,7 +26,7 @@ public class FirebaseAnalytics {
                     if (!task.isSuccessful()) {
                         Exception exception = task.getException();
                         Log.w(FirebaseAnalyticsPlugin.TAG, "Get AppInstanceId failed.", exception);
-                        resultCallback.error(exception.getLocalizedMessage());
+                        resultCallback.error(exception.getMessage());
                         return;
                     }
 

--- a/packages/analytics/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/analytics/FirebaseAnalyticsPlugin.java
+++ b/packages/analytics/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/analytics/FirebaseAnalyticsPlugin.java
@@ -44,7 +44,7 @@ public class FirebaseAnalyticsPlugin extends Plugin {
             );
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -56,7 +56,7 @@ public class FirebaseAnalyticsPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -73,7 +73,7 @@ public class FirebaseAnalyticsPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -86,7 +86,7 @@ public class FirebaseAnalyticsPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -103,7 +103,7 @@ public class FirebaseAnalyticsPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -115,7 +115,7 @@ public class FirebaseAnalyticsPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -131,7 +131,7 @@ public class FirebaseAnalyticsPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -147,7 +147,7 @@ public class FirebaseAnalyticsPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 }

--- a/packages/app-check/BREAKING.md
+++ b/packages/app-check/BREAKING.md
@@ -17,3 +17,9 @@ If you want to use this plugin with Capacitor 4, please install version `1.4.0`:
 ```
 npm i @capacitor-firebase/app-check@1.4.0
 ```
+
+### Localized error messages
+
+On Android, error messages were previously generated with `getLocalizedMessage`. They are no longer localized and are generated with `getMessage` instead.
+
+You should therefore check your error handling.

--- a/packages/app-check/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/appcheck/FirebaseAppCheck.java
+++ b/packages/app-check/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/appcheck/FirebaseAppCheck.java
@@ -22,7 +22,7 @@ public class FirebaseAppCheck {
             .addOnFailureListener(
                 exception -> {
                     Log.w(FirebaseAppCheckPlugin.TAG, "Get App Check token failed.", exception);
-                    resultCallback.error(exception.getLocalizedMessage());
+                    resultCallback.error(exception.getMessage());
                 }
             );
     }

--- a/packages/app-check/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/appcheck/FirebaseAppCheckPlugin.java
+++ b/packages/app-check/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/appcheck/FirebaseAppCheckPlugin.java
@@ -38,7 +38,7 @@ public class FirebaseAppCheckPlugin extends Plugin {
             );
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -51,7 +51,7 @@ public class FirebaseAppCheckPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -67,7 +67,7 @@ public class FirebaseAppCheckPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 }

--- a/packages/app/BREAKING.md
+++ b/packages/app/BREAKING.md
@@ -19,6 +19,12 @@ If you want to use this plugin with Capacitor 4, please install version `1.4.0`:
 npm i @capacitor-firebase/app@1.4.0
 ```
 
+### Localized error messages
+
+On Android, error messages were previously generated with `getLocalizedMessage`. They are no longer localized and are generated with `getMessage` instead.
+
+You should therefore check your error handling.
+
 ## Version 1.x.x
 
 ### Capacitor 4

--- a/packages/app/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/capawesome/FirebaseAppPlugin.java
+++ b/packages/app/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/capawesome/FirebaseAppPlugin.java
@@ -27,7 +27,7 @@ public class FirebaseAppPlugin extends Plugin {
             call.resolve(ret);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -45,7 +45,7 @@ public class FirebaseAppPlugin extends Plugin {
             call.resolve(ret);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 }

--- a/packages/authentication/BREAKING.md
+++ b/packages/authentication/BREAKING.md
@@ -20,6 +20,12 @@ If you want to use this plugin with Capacitor 4, please install version `1.4.0`:
 npm i @capacitor-firebase/authentication@1.4.0
 ```
 
+### Localized error messages
+
+On Android, error messages were previously generated with `getLocalizedMessage`. They are no longer localized and are generated with `getMessage` instead.
+
+You should therefore check your error handling.
+
 ## Version 1.x.x
 
 ### Capacitor 4

--- a/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthentication.java
+++ b/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthentication.java
@@ -158,7 +158,7 @@ public class FirebaseAuthentication {
                     String token = task.getResult().getToken();
                     resultCallback.success(token);
                 } else {
-                    String message = task.getException().getLocalizedMessage();
+                    String message = task.getException().getMessage();
                     resultCallback.error(message);
                 }
             }
@@ -351,7 +351,7 @@ public class FirebaseAuthentication {
                         call.resolve(signInResult);
                     } else {
                         Logger.error(TAG, "signInAnonymously failed.", task.getException());
-                        call.reject(task.getException().getLocalizedMessage());
+                        call.reject(task.getException().getMessage());
                     }
                 }
             );
@@ -649,7 +649,7 @@ public class FirebaseAuthentication {
     public void handleFailedSignIn(final PluginCall call, String message, Exception exception) {
         Logger.error(TAG, exception.getMessage(), exception);
         if (message == null && exception != null) {
-            message = exception.getLocalizedMessage();
+            message = exception.getMessage();
         }
         call.reject(message, exception);
     }
@@ -704,7 +704,7 @@ public class FirebaseAuthentication {
     public void handleFailedLink(final PluginCall call, String message, Exception exception) {
         Logger.error(TAG, exception.getMessage(), exception);
         if (message == null && exception != null) {
-            message = exception.getLocalizedMessage();
+            message = exception.getMessage();
         }
         call.reject(message, exception);
     }

--- a/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthenticationPlugin.java
+++ b/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthenticationPlugin.java
@@ -72,7 +72,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.applyActionCode(oobCode, () -> call.resolve());
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -92,7 +92,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.confirmPasswordReset(oobCode, newPassword, () -> call.resolve());
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -102,7 +102,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.createUserWithEmailAndPassword(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -117,7 +117,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.deleteUser(user, () -> call.resolve());
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -131,7 +131,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             call.resolve(result);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -158,7 +158,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             );
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -175,7 +175,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             call.resolve(result);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -192,7 +192,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             call.resolve(result);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -202,7 +202,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.linkWithApple(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -212,7 +212,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.linkWithEmailAndPassword(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -222,7 +222,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.linkWithEmailLink(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -232,7 +232,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.linkWithFacebook(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -242,7 +242,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.linkWithGithub(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -252,7 +252,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.linkWithGoogle(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -262,7 +262,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.linkWithMicrosoft(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -281,7 +281,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.linkWithPhoneNumber(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -291,7 +291,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.linkWithPlayGames(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -301,7 +301,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.linkWithTwitter(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -311,7 +311,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.linkWithYahoo(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -326,7 +326,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.reload(user, () -> call.resolve());
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -341,7 +341,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.sendEmailVerification(user, () -> call.resolve());
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -356,7 +356,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.sendPasswordResetEmail(email, () -> call.resolve());
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -395,7 +395,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.sendSignInLinkToEmail(email, actionCodeSettings.build(), () -> call.resolve());
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -408,7 +408,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -425,7 +425,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -435,7 +435,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.signInAnonymously(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -445,7 +445,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.signInWithApple(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -460,7 +460,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.signInWithCustomToken(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -470,7 +470,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.signInWithEmailAndPassword(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -480,7 +480,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.signInWithEmailLink(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -490,7 +490,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.signInWithFacebook(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -500,7 +500,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.signInWithGithub(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -510,7 +510,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.signInWithGoogle(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -520,7 +520,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.signInWithMicrosoft(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -539,7 +539,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.signInWithPhoneNumber(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -549,7 +549,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.signInWithPlayGames(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -559,7 +559,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.signInWithTwitter(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -569,7 +569,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.signInWithYahoo(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -579,7 +579,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.signOut(call);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -599,7 +599,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.unlink(call, user, providerId);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -619,7 +619,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.updateEmail(user, newEmail, () -> call.resolve());
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -639,7 +639,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.updatePassword(user, newPassword, () -> call.resolve());
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -656,7 +656,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             implementation.updateProfile(user, displayName, photoUrl, () -> call.resolve());
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -667,7 +667,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -685,7 +685,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -698,7 +698,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
     public void handlePhoneVerificationFailed(Exception exception) {
         Logger.error(TAG, exception.getMessage(), exception);
         JSObject result = new JSObject();
-        result.put("message", exception.getLocalizedMessage());
+        result.put("message", exception.getMessage());
         notifyListeners(PHONE_VERIFICATION_FAILED_EVENT, result, true);
     }
 

--- a/packages/crashlytics/BREAKING.md
+++ b/packages/crashlytics/BREAKING.md
@@ -19,6 +19,12 @@ If you want to use this plugin with Capacitor 4, please install version `1.4.0`:
 npm i @capacitor-firebase/crashlytics@1.4.0
 ```
 
+### Localized error messages
+
+On Android, error messages were previously generated with `getLocalizedMessage`. They are no longer localized and are generated with `getMessage` instead.
+
+You should therefore check your error handling.
+
 ## Version 1.x.x
 
 ### Capacitor 4

--- a/packages/crashlytics/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/crashlytics/FirebaseCrashlyticsPlugin.java
+++ b/packages/crashlytics/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/crashlytics/FirebaseCrashlyticsPlugin.java
@@ -53,7 +53,7 @@ public class FirebaseCrashlyticsPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -69,7 +69,7 @@ public class FirebaseCrashlyticsPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -85,7 +85,7 @@ public class FirebaseCrashlyticsPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -101,7 +101,7 @@ public class FirebaseCrashlyticsPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -119,7 +119,7 @@ public class FirebaseCrashlyticsPlugin extends Plugin {
             call.resolve(ret);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -130,7 +130,7 @@ public class FirebaseCrashlyticsPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -141,7 +141,7 @@ public class FirebaseCrashlyticsPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -159,7 +159,7 @@ public class FirebaseCrashlyticsPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 }

--- a/packages/messaging/BREAKING.md
+++ b/packages/messaging/BREAKING.md
@@ -21,6 +21,12 @@ If you want to use this plugin with Capacitor 4, please install version `1.4.0`:
 npm i @capacitor-firebase/messaging@1.4.0
 ```
 
+### Localized error messages
+
+On Android, error messages were previously generated with `getLocalizedMessage`. They are no longer localized and are generated with `getMessage` instead.
+
+You should therefore check your error handling.
+
 ## Version 1.x.x
 
 ### Capacitor 4

--- a/packages/messaging/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/messaging/FirebaseMessaging.java
+++ b/packages/messaging/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/messaging/FirebaseMessaging.java
@@ -34,7 +34,7 @@ public class FirebaseMessaging {
                     if (!task.isSuccessful()) {
                         Exception exception = task.getException();
                         Log.w(FirebaseMessagingPlugin.TAG, "Fetching FCM registration token failed", exception);
-                        resultCallback.error(exception.getLocalizedMessage());
+                        resultCallback.error(exception.getMessage());
                         return;
                     }
 

--- a/packages/messaging/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/messaging/FirebaseMessagingPlugin.java
+++ b/packages/messaging/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/messaging/FirebaseMessagingPlugin.java
@@ -106,7 +106,7 @@ public class FirebaseMessagingPlugin extends Plugin {
             );
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -117,7 +117,7 @@ public class FirebaseMessagingPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -136,7 +136,7 @@ public class FirebaseMessagingPlugin extends Plugin {
             call.resolve(result);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -173,7 +173,7 @@ public class FirebaseMessagingPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -184,7 +184,7 @@ public class FirebaseMessagingPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -200,7 +200,7 @@ public class FirebaseMessagingPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -216,7 +216,7 @@ public class FirebaseMessagingPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -239,7 +239,7 @@ public class FirebaseMessagingPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -260,7 +260,7 @@ public class FirebaseMessagingPlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -282,7 +282,7 @@ public class FirebaseMessagingPlugin extends Plugin {
             call.resolve(result);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 

--- a/packages/performance/BREAKING.md
+++ b/packages/performance/BREAKING.md
@@ -19,6 +19,12 @@ If you want to use this plugin with Capacitor 4, please install version `1.4.0`:
 npm i @capacitor-firebase/performance@1.4.0
 ```
 
+### Localized error messages
+
+On Android, error messages were previously generated with `getLocalizedMessage`. They are no longer localized and are generated with `getMessage` instead.
+
+You should therefore check your error handling.
+
 ## Version 1.x.x
 
 ### Capacitor 4

--- a/packages/performance/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/performance/FirebasePerformancePlugin.java
+++ b/packages/performance/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/performance/FirebasePerformancePlugin.java
@@ -36,7 +36,7 @@ public class FirebasePerformancePlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -57,7 +57,7 @@ public class FirebasePerformancePlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -84,7 +84,7 @@ public class FirebasePerformancePlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -100,7 +100,7 @@ public class FirebasePerformancePlugin extends Plugin {
             call.resolve();
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -113,7 +113,7 @@ public class FirebasePerformancePlugin extends Plugin {
             call.resolve(result);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 }

--- a/packages/remote-config/BREAKING.md
+++ b/packages/remote-config/BREAKING.md
@@ -17,3 +17,9 @@ If you want to use this plugin with Capacitor 4, please install version `1.4.0`:
 ```
 npm i @capacitor-firebase/remote-config@1.4.0
 ```
+
+### Localized error messages
+
+On Android, error messages were previously generated with `getLocalizedMessage`. They are no longer localized and are generated with `getMessage` instead.
+
+You should therefore check your error handling.

--- a/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -22,7 +22,7 @@ public class FirebaseRemoteConfig {
             .addOnFailureListener(
                 exception -> {
                     Log.w(FirebaseRemoteConfigPlugin.TAG, "Activate config failed.", exception);
-                    resultCallback.error(exception.getLocalizedMessage());
+                    resultCallback.error(exception.getMessage());
                 }
             );
     }
@@ -38,7 +38,7 @@ public class FirebaseRemoteConfig {
             .addOnFailureListener(
                 exception -> {
                     Log.w(FirebaseRemoteConfigPlugin.TAG, "Fetch and activate config failed.", exception);
-                    resultCallback.error(exception.getLocalizedMessage());
+                    resultCallback.error(exception.getMessage());
                 }
             );
     }
@@ -54,7 +54,7 @@ public class FirebaseRemoteConfig {
             .addOnFailureListener(
                 exception -> {
                     Log.w(FirebaseRemoteConfigPlugin.TAG, "Fetch config failed.", exception);
-                    resultCallback.error(exception.getLocalizedMessage());
+                    resultCallback.error(exception.getMessage());
                 }
             );
     }

--- a/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
+++ b/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
@@ -32,7 +32,7 @@ public class FirebaseRemoteConfigPlugin extends Plugin {
             );
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -54,7 +54,7 @@ public class FirebaseRemoteConfigPlugin extends Plugin {
             );
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -78,7 +78,7 @@ public class FirebaseRemoteConfigPlugin extends Plugin {
             );
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -97,7 +97,7 @@ public class FirebaseRemoteConfigPlugin extends Plugin {
             call.resolve(result);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -116,7 +116,7 @@ public class FirebaseRemoteConfigPlugin extends Plugin {
             call.resolve(result);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 
@@ -135,7 +135,7 @@ public class FirebaseRemoteConfigPlugin extends Plugin {
             call.resolve(result);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
-            call.reject(exception.getLocalizedMessage());
+            call.reject(exception.getMessage());
         }
     }
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The changes have been tested successfully.
- [ ] A changeset has been created (`npm run changeset`).

Close #200