### PR TITLE
fix(analytics): pod `FirebaseAnalyticsWithoutAdIdSupport` does not exist

### DIFF
--- a/.changeset/spicy-turkeys-impress.md
+++ b/.changeset/spicy-turkeys-impress.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/analytics': patch
+---
+
+fix(ios): pod `FirebaseAnalyticsWithoutAdIdSupport` does not exist

--- a/packages/analytics/CapacitorFirebaseAnalytics.podspec
+++ b/packages/analytics/CapacitorFirebaseAnalytics.podspec
@@ -26,6 +26,6 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'AnalyticsWithoutAdIdSupport' do |analyticsWithoutAdIdSupport|
-    analyticsWithoutAdIdSupport.dependency 'FirebaseAnalyticsWithoutAdIdSupport', '10.8.0'
+    analyticsWithoutAdIdSupport.dependency 'FirebaseAnalytics/WithoutAdIdSupport', '10.8.0'
   end
 end


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The changes have been tested successfully.
- [ ] A changeset has been created (`npm run changeset`).

Close #376 