### PR TITLE
feat(authentication): update Firebase Auth for Android to 22.1.2

### DIFF
--- a/.changeset/tasty-mirrors-wave.md
+++ b/.changeset/tasty-mirrors-wave.md
@@ -2,4 +2,4 @@
 '@capacitor-firebase/authentication': patch
 ---
 
-feat(authentication): update Firebase Auth for Android to 22.1.2
+feat(android): update `com.google.firebase:firebase-auth` to version `22.1.2`

--- a/.changeset/tasty-mirrors-wave.md
+++ b/.changeset/tasty-mirrors-wave.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/authentication': patch
+---
+
+feat(authentication): update Firebase Auth for Android to 22.1.2

--- a/.changeset/tasty-mirrors-wave.md
+++ b/.changeset/tasty-mirrors-wave.md
@@ -1,5 +1,5 @@
 ---
-'@capacitor-firebase/authentication': patch
+'@capacitor-firebase/authentication': minor
 ---
 
 feat(android): update `com.google.firebase:firebase-auth` to version `22.1.2`

--- a/packages/authentication/README.md
+++ b/packages/authentication/README.md
@@ -1665,7 +1665,7 @@ Remove all listeners for this plugin.
 | Prop                    | Type                 | Description                                                                                                                                                   | Default            | Since |
 | ----------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ----- |
 | **`phoneNumber`**       | <code>string</code>  | The phone number to be verified in E.164 format.                                                                                                              |                    | 0.1.0 |
-| **`recaptchaVerifier`** | <code>unknown</code> | The reCAPTCHA verifier. Must be an instance of `firebase.auth.RecaptchaVerifier`. Only available for Web.                                                     |                    | 1.3.0 |
+| **`recaptchaVerifier`** | <code>unknown</code> | The reCAPTCHA verifier. Must be an instance of `firebase.auth.RecaptchaVerifier`. Only available for Web.                                                     |                    | 5.2.0 |
 | **`resendCode`**        | <code>boolean</code> | Resend the verification code to the specified phone number. `signInWithPhoneNumber` must be called once before using this option. Only available for Android. | <code>false</code> | 1.3.0 |
 
 

--- a/packages/authentication/android/build.gradle
+++ b/packages/authentication/android/build.gradle
@@ -5,7 +5,7 @@ ext {
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.5.1'
     rgcfaIncludeGoogle = project.hasProperty('rgcfaIncludeGoogle') ? rootProject.ext.rgcfaIncludeGoogle : false
     rgcfaIncludeFacebook = project.hasProperty('rgcfaIncludeFacebook') ? rootProject.ext.rgcfaIncludeFacebook : false
-    firebaseAuthVersion = project.hasProperty('firebaseAuthVersion') ? rootProject.ext.firebaseAuthVersion : '21.2.0'
+    firebaseAuthVersion = project.hasProperty('firebaseAuthVersion') ? rootProject.ext.firebaseAuthVersion : '22.1.2'
     playServicesAuthVersion = project.hasProperty('playServicesAuthVersion') ? rootProject.ext.playServicesAuthVersion : '20.5.0'
     facebookLoginVersion = project.hasProperty('facebookLoginVersion') ? rootProject.ext.facebookLoginVersion : '16.0.0'
 }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] The changes have been tested successfully.
- [X] A changeset has been created (`npm run changeset`).

This pull request updates the Firebase Authentication library for Android to 22.1.2. Using version 21 shows a message in Play Console warning the developer that the SafetyNet API will be discontinued soon:

![play_console_safetynet_issue](https://github.com/capawesome-team/capacitor-firebase/assets/4135191/6889846f-9cdc-44b4-bb64-04fed1ceab5d)

The version 22 removed SafetyNet support for app verification during phone number authentication (see changelog [here](https://firebase.google.com/support/release-notes/android#auth_v22-0-0)). Although it is marked as a breaking change, this does not seem to affect the functionality of this plugin. SafetyNet will be discontinued soon as mentioned in their [deprecation timeline](https://developer.android.com/training/safetynet/deprecation-timeline). This link also gives information on how to migrate to the new Play Integrity API.

