### PR TITLE
Enriched error logging

### DIFF
--- a/.changeset/fuzzy-days-enjoy.md
+++ b/.changeset/fuzzy-days-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/authentication': patch
+---
+
+Extended error logging

--- a/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthentication.java
+++ b/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthentication.java
@@ -742,7 +742,7 @@ public class FirebaseAuthentication {
 
     public void handleFailedSignIn(@NonNull final PluginCall call, @Nullable String message, @Nullable Exception exception) {
         if (message == null && exception != null) {
-            message = exception.getMessage();
+            message = exception.toString();
         }
         Logger.error(TAG, message, exception);
         String code = FirebaseAuthenticationHelper.createErrorCode(exception);
@@ -802,7 +802,7 @@ public class FirebaseAuthentication {
 
     public void handleFailedLink(final PluginCall call, String message, Exception exception) {
         if (message == null && exception != null) {
-            message = exception.getMessage();
+            message = exception.toString();
         }
         Logger.error(TAG, message, exception);
         String code = FirebaseAuthenticationHelper.createErrorCode(exception);


### PR DESCRIPTION
This gives way better errors for Sentry or Firebase than the error message before. It was looking like this

![Bildschirmfoto 2023-10-10 um 15 55 40](https://github.com/capawesome-team/capacitor-firebase/assets/10534316/39d82fed-cb17-40b0-b6fe-e7817cf61906)

and now there is more information passed

![Bildschirmfoto 2023-10-10 um 15 55 20](https://github.com/capawesome-team/capacitor-firebase/assets/10534316/1ceaa26e-dc00-42a2-86fd-d0c51fdc5753)


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
