### PR TITLE
Issue #474

### DIFF
--- a/packages/firestore/README.md
+++ b/packages/firestore/README.md
@@ -472,6 +472,9 @@ Remove all listeners for this plugin.
 
 #### DocumentData
 
+Document data (for use with {@link @firebase/firestore/lite#(setDoc:1)}) consists of fields mapped to
+values.
+
 
 #### SetDocumentOptions
 
@@ -640,6 +643,9 @@ Remove all listeners for this plugin.
 
 #### QueryFilterConstraint
 
+<a href="#queryfilterconstraint">`QueryFilterConstraint`</a> is a helper union type that represents
+{@link <a href="#queryfieldfilterconstraint">QueryFieldFilterConstraint</a>} and {@link <a href="#querycompositefilterconstraint">QueryCompositeFilterConstraint</a>}.
+
 <code><a href="#queryfieldfilterconstraint">QueryFieldFilterConstraint</a> | <a href="#querycompositefilterconstraint">QueryCompositeFilterConstraint</a></code>
 
 
@@ -650,10 +656,21 @@ Remove all listeners for this plugin.
 
 #### QueryNonFilterConstraint
 
+<a href="#querynonfilterconstraint">`QueryNonFilterConstraint`</a> is a helper union type that represents
+QueryConstraints which are used to narrow or order the set of documents,
+but that do not explicitly filter on a document field.
+`QueryNonFilterConstraint`s are created by invoking {@link orderBy},
+{@link (startAt:1)}, {@link (startAfter:1)}, {@link (endBefore:1)}, {@link (endAt:1)},
+{@link limit} or {@link limitToLast} and can then be passed to {@link (query:1)}
+to create a new query instance that also contains the `QueryConstraint`.
+
 <code><a href="#queryorderbyconstraint">QueryOrderByConstraint</a> | <a href="#querylimitconstraint">QueryLimitConstraint</a> | <a href="#querystartatconstraint">QueryStartAtConstraint</a> | <a href="#queryendatconstraint">QueryEndAtConstraint</a></code>
 
 
 #### OrderByDirection
+
+The direction of a {@link orderBy} clause is specified as 'desc' or 'asc'
+(descending or ascending).
 
 <code>'desc' | 'asc'</code>
 

--- a/packages/firestore/ios/Plugin/FirebaseFirestoreHelper.swift
+++ b/packages/firestore/ios/Plugin/FirebaseFirestoreHelper.swift
@@ -7,7 +7,21 @@ public class FirebaseFirestoreHelper {
         var map: [String: Any] = [:]
         for key in object.keys {
             if let value = object[key] {
-                map[key] = value
+                if value is Dictionary<String, JSValue> {
+                    let val = value as! Dictionary<String, JSValue>
+                    if (val.keys.contains("type")) {
+                        let s = Int64(val["seconds"] as! String) ?? 0;
+                        let n = Int32(val["nanoseconds"] as! String) ?? 0;
+                        let t = Timestamp(seconds: s, nanoseconds: n);
+                        // b. serialized timestamp converstion
+                        print("CONVERTED A TIMESTAMP", t);
+                        map[key] = t;
+                    } else {
+                        map[key] = value
+                    }
+                } else {
+                    map[key] = value
+                }
             }
         }
         return map
@@ -61,6 +75,11 @@ public class FirebaseFirestoreHelper {
     }
 
     private static func createJSValue(value: Any?) -> JSValue? {
+        if value is Timestamp {
+            let val = value as! Timestamp;
+            return [ "type": "timestamp", "seconds": String(val.seconds), "nanoseconds": String(val.nanoseconds) ];
+        }
+
         guard let value = value else {
             return nil
         }

--- a/packages/firestore/src/index.ts
+++ b/packages/firestore/src/index.ts
@@ -1,13 +1,20 @@
-import { registerPlugin } from '@capacitor/core';
+import { Capacitor, registerPlugin } from '@capacitor/core';
+
+import { FirebaseFirestoreNative } from "./native";
 
 import type { FirebaseFirestorePlugin } from './definitions';
 
-const FirebaseFirestore = registerPlugin<FirebaseFirestorePlugin>(
+
+let FirebaseFirestore = registerPlugin<FirebaseFirestorePlugin>(
   'FirebaseFirestore',
   {
     web: () => import('./web').then(m => new m.FirebaseFirestoreWeb()),
   },
 );
+
+if (Capacitor.isNativePlatform() && Capacitor.getPlatform() == "ios") {
+  FirebaseFirestore = new FirebaseFirestoreNative(FirebaseFirestore);
+}
 
 export * from './definitions';
 export { FirebaseFirestore };

--- a/packages/firestore/src/native.ts
+++ b/packages/firestore/src/native.ts
@@ -1,0 +1,158 @@
+import { Timestamp } from "firebase/firestore";
+import { AddCollectionSnapshotListenerCallback, AddDocumentSnapshotListenerCallbackEvent, AddCollectionSnapshotListenerCallbackEvent, AddCollectionSnapshotListenerOptions, AddDocumentOptions, AddDocumentResult, AddDocumentSnapshotListenerCallback, AddDocumentSnapshotListenerOptions, DeleteDocumentOptions, DocumentData, GetCollectionGroupOptions, GetCollectionGroupResult, GetCollectionOptions, GetCollectionResult, GetDocumentOptions, GetDocumentResult, RemoveSnapshotListenerOptions, SetDocumentOptions, UpdateDocumentOptions } from "./definitions";
+import { FirebaseFirestorePlugin } from "./definitions";
+
+type SerializedTimeStamp = {
+    type: 'timestamp',
+    seconds: string, // parses to a number
+    nanoseconds: string, // parses to a  number
+}
+
+function fromNativeTimestamp(ts:SerializedTimeStamp): Timestamp {
+    let s = Number(ts.seconds);
+    let n = Number(ts.nanoseconds);
+    return new Timestamp(s, n);
+}
+
+function toNativeTimestamp(ts:Timestamp): SerializedTimeStamp {
+    return {
+        type: 'timestamp',
+        seconds: ts.seconds.toString(),
+        nanoseconds: ts.nanoseconds.toString(),
+    }
+}
+
+
+/**
+ * @param data DocumentSnapshot.data 
+ */
+function formatDocumentToNative(data:any): any {
+    // 1. format timestamps
+    for (let key in data) {
+        let val = data[key];
+        if (val instanceof Timestamp) {
+            data[key] = toNativeTimestamp(val)
+        }
+    }
+    return data;
+}
+
+
+/**
+ * 
+ * @param data DocumentSnapshot.data 
+ * @returns 
+ */
+function formatDocumentFromNative(data:any): any {
+    // 1. format timestamps
+    for (let key in data) {
+        let val = data[key];
+        if (val.hasOwnProperty("type") && val.type == 'timestamp') {
+            data[key] = fromNativeTimestamp(val)
+        }
+    }
+    return data;
+}
+
+export class FirebaseFirestoreNative implements FirebaseFirestorePlugin {
+    nativeRef: FirebaseFirestorePlugin
+    constructor(nativePlugin: FirebaseFirestorePlugin) {
+        this.nativeRef = nativePlugin;
+    }
+
+    addDocument(options: AddDocumentOptions): Promise<AddDocumentResult> {
+        // web -> native
+        formatDocumentToNative(options.data);
+        return this.nativeRef.addDocument(options);
+    }
+
+    setDocument(options: SetDocumentOptions): Promise<void> {
+        // web -> native
+        formatDocumentToNative(options.data);
+        return this.nativeRef.setDocument(options);
+    }
+
+    getDocument<T extends DocumentData = DocumentData>(options: GetDocumentOptions): Promise<GetDocumentResult<T>> {
+        console.log("NATIVE WRAPPER");
+        return this.nativeRef.getDocument(options)
+            .then(res => {
+                // native -> web
+                formatDocumentFromNative(res.snapshot.data);
+                return res as GetDocumentResult<T>;
+            })
+    }
+
+    updateDocument(options: UpdateDocumentOptions): Promise<void> {
+        // web -> native
+        formatDocumentToNative(options.data);
+        return this.nativeRef.updateDocument(options);
+    }
+
+    deleteDocument(options: DeleteDocumentOptions): Promise<void> {
+        return this.nativeRef.deleteDocument(options);
+    }
+
+    getCollection<T extends DocumentData = DocumentData>(options: GetCollectionOptions): Promise<GetCollectionResult<T>> {
+        return this.nativeRef.getCollection(options)
+            .then(res => {
+                // native -> web
+                for (let snap of res.snapshots) {
+                    formatDocumentFromNative(snap.data);
+                }
+                return res as GetCollectionGroupResult<T>;
+            });
+    }
+
+    getCollectionGroup<T extends DocumentData = DocumentData>(options: GetCollectionGroupOptions): Promise<GetCollectionGroupResult<T>> {
+        return this.nativeRef.getCollectionGroup(options)
+            .then(res => {
+                // native -> web
+                for (let snap of res.snapshots) {
+                    formatDocumentFromNative(snap.data);
+                }
+                return res as GetCollectionGroupResult<T>;
+            });
+    }
+
+    clearPersistence(): Promise<void> {
+        return this.nativeRef.clearPersistence();
+    }
+
+    enableNetwork(): Promise<void> {
+        return this.nativeRef.enableNetwork();
+    }
+
+    disableNetwork(): Promise<void> {
+        return this.nativeRef.disableNetwork();
+    }
+
+    addDocumentSnapshotListener<T extends DocumentData = DocumentData>(options: AddDocumentSnapshotListenerOptions, callback: AddDocumentSnapshotListenerCallback<T>): Promise<string> {
+        return this.nativeRef.addDocumentSnapshotListener(options, (event:AddDocumentSnapshotListenerCallbackEvent<T> | null, error) => {
+            if (event) {
+                // native -> web
+                formatDocumentFromNative(event.snapshot.data);
+            }
+            callback(event, error);
+        });
+    }
+
+    addCollectionSnapshotListener<T extends DocumentData = DocumentData>(options: AddCollectionSnapshotListenerOptions, callback: AddCollectionSnapshotListenerCallback<T>): Promise<string> {
+        return this.nativeRef.addCollectionSnapshotListener(options, (event:AddCollectionSnapshotListenerCallbackEvent<T> | null, error) => {
+            if (event) {
+                // native -> web
+                for (let snap of event.snapshots) {
+                    formatDocumentFromNative(snap.data);
+                }
+            }
+            callback(event, error);
+        });
+    }
+
+    removeSnapshotListener(options: RemoveSnapshotListenerOptions): Promise<void> {
+        return this.nativeRef.removeSnapshotListener(options);
+    }
+
+    removeAllListeners(): Promise<void> {
+        return this.nativeRef.removeAllListeners();
+    }
+}


### PR DESCRIPTION
Salutations and hello, all!

This PR is related to issue #474, reported, yesterday. This is my current workaround that I'm using to continue to make use of the project. **_It all comes down to using a simple serialized format for Google's `Timestamp` type, re-initializing it whenever it passes between the web and the native layers, but it probably shouldn't be merged as is._** This is my first contribution to CapAwesome and I'm still getting the lay of the land (what's more, my Swift is pretty weak). To constitute a full solution, I'm imagining something as follows....

1. Recursively check child JSObjects for `Timestamp` types and convert as needed (this commit is only a superficial check).

I'm imagining that this would involve the following:
1. Creating a local extension of JSType that includes `Timestamp` as a potential value
2. Moving the serialization logic somewhere else


@robingenz, I should have more time this weekend to work on my Swift-ese and create a more elegant solution on the iOS side. I could probably figure out the Android side, too, but I don't particularly want to. 😅