### PR TITLE
UpoadFileOptions -> UploadFileOptionsWithMetadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15394,7 +15394,7 @@
     },
     "packages/analytics": {
       "name": "@capacitor-firebase/analytics",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "funding": [
         {
           "type": "github",
@@ -15447,7 +15447,7 @@
     },
     "packages/app": {
       "name": "@capacitor-firebase/app",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "funding": [
         {
           "type": "github",
@@ -15488,7 +15488,7 @@
     },
     "packages/app-check": {
       "name": "@capacitor-firebase/app-check",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "funding": [
         {
           "type": "github",
@@ -15553,7 +15553,7 @@
     },
     "packages/authentication": {
       "name": "@capacitor-firebase/authentication",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "funding": [
         {
           "type": "github",
@@ -15606,7 +15606,7 @@
     },
     "packages/crashlytics": {
       "name": "@capacitor-firebase/crashlytics",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "funding": [
         {
           "type": "github",
@@ -15658,7 +15658,7 @@
     },
     "packages/firestore": {
       "name": "@capacitor-firebase/firestore",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "funding": [
         {
           "type": "github",
@@ -15711,7 +15711,7 @@
     },
     "packages/messaging": {
       "name": "@capacitor-firebase/messaging",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "funding": [
         {
           "type": "github",
@@ -15764,7 +15764,7 @@
     },
     "packages/performance": {
       "name": "@capacitor-firebase/performance",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "funding": [
         {
           "type": "github",
@@ -15817,7 +15817,7 @@
     },
     "packages/remote-config": {
       "name": "@capacitor-firebase/remote-config",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "funding": [
         {
           "type": "github",
@@ -15870,7 +15870,7 @@
     },
     "packages/storage": {
       "name": "@capacitor-firebase/storage",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "funding": [
         {
           "type": "github",

--- a/packages/storage/rollup.config.js
+++ b/packages/storage/rollup.config.js
@@ -7,7 +7,6 @@ export default {
       name: 'capacitorFirebaseStorage',
       globals: {
         '@capacitor/core': 'capacitorExports',
-        'firebase/storage': 'firebaseStorage',
       },
       sourcemap: true,
       inlineDynamicImports: true,
@@ -19,5 +18,5 @@ export default {
       inlineDynamicImports: true,
     },
   ],
-  external: ['@capacitor/core', 'firebase/storage'],
+  external: ['@capacitor/core'],
 };

--- a/packages/storage/rollup.config.js
+++ b/packages/storage/rollup.config.js
@@ -7,6 +7,7 @@ export default {
       name: 'capacitorFirebaseStorage',
       globals: {
         '@capacitor/core': 'capacitorExports',
+        'firebase/storage': 'firebaseStorage',
       },
       sourcemap: true,
       inlineDynamicImports: true,
@@ -18,5 +19,5 @@ export default {
       inlineDynamicImports: true,
     },
   ],
-  external: ['@capacitor/core'],
+  external: ['@capacitor/core', 'firebase/storage'],
 };

--- a/packages/storage/src/definitions.ts
+++ b/packages/storage/src/definitions.ts
@@ -35,7 +35,9 @@ export interface FirebaseStoragePlugin {
    * @since 5.3.0
    */
   uploadFile(
-    options: UploadFileOptions,
+    // [-] Original: options: UploadFileOptions
+    // [+] Issue #506: UploadFileOptionsWithMetadata added in options
+    options: UploadFileOptionsWithMetadata,
     callback: UploadFileCallback,
   ): Promise<CallbackId>;
 }
@@ -321,6 +323,18 @@ export interface UploadFileOptions {
    * @example 'file:///var/mobile/Containers/Data/Application/E397A70D-67E4-4258-236E-W1D9E12111D4/Library/Caches/092F8464-DE60-40B3-8A23-EB83160D9F9F/mountains.png'
    */
   uri?: string;
+}
+
+// [+] Issue: #506, Adding interface for UploadFileOptions with metadata: UploadFileOptionsWithMetadata
+export interface UploadFileOptionsWithMetadata extends UploadFileOptions {
+  metadata?: {
+    cacheControl?: string | undefined; 
+    contentDisposition?: string | undefined;
+    contentEncoding?: string | undefined;
+    contentLanguage?: string | undefined;
+    contentType?: string | undefined;
+    customMetadata?: { [key: string]: string } | undefined;
+  };
 }
 
 /**


### PR DESCRIPTION
PR #506 

changes in definitions.ts

```diff

// ... (other methods)

- options: UploadFileOptionsWithMetadata, // Line: 38
+ options: options: UploadFileOptionsWithMetadata, // Line: 40

// ... (other methods)

+ export interface UploadFileOptionsWithMetadata extends UploadFileOptions {   // Line: 329
+ metadata?: {
+   cacheControl?: string | undefined; 
+    contentDisposition?: string | undefined;
+    contentEncoding?: string | undefined;
+    contentLanguage?: string | undefined;
+    contentType?: string | undefined;
+    customMetadata?: { [key: string]: string } | undefined;
+  };
+ }

// ... (other methods)
