### PR TITLE
Fix/510: Removed QueryDocumentSnapshot interface

### DIFF
--- a/.changeset/famous-cougars-unite.md
+++ b/.changeset/famous-cougars-unite.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/firestore': major
+---
+
+Removed QueryDocumentSnapshot interface and added DocumentSnapshot in GetCollectionResult

--- a/package-lock.json
+++ b/package-lock.json
@@ -15394,7 +15394,7 @@
     },
     "packages/analytics": {
       "name": "@capacitor-firebase/analytics",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "funding": [
         {
           "type": "github",
@@ -15447,7 +15447,7 @@
     },
     "packages/app": {
       "name": "@capacitor-firebase/app",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "funding": [
         {
           "type": "github",
@@ -15488,7 +15488,7 @@
     },
     "packages/app-check": {
       "name": "@capacitor-firebase/app-check",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "funding": [
         {
           "type": "github",
@@ -15553,7 +15553,7 @@
     },
     "packages/authentication": {
       "name": "@capacitor-firebase/authentication",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "funding": [
         {
           "type": "github",
@@ -15606,7 +15606,7 @@
     },
     "packages/crashlytics": {
       "name": "@capacitor-firebase/crashlytics",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "funding": [
         {
           "type": "github",
@@ -15658,7 +15658,7 @@
     },
     "packages/firestore": {
       "name": "@capacitor-firebase/firestore",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "funding": [
         {
           "type": "github",
@@ -15711,7 +15711,7 @@
     },
     "packages/messaging": {
       "name": "@capacitor-firebase/messaging",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "funding": [
         {
           "type": "github",
@@ -15764,7 +15764,7 @@
     },
     "packages/performance": {
       "name": "@capacitor-firebase/performance",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "funding": [
         {
           "type": "github",
@@ -15817,7 +15817,7 @@
     },
     "packages/remote-config": {
       "name": "@capacitor-firebase/remote-config",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "funding": [
         {
           "type": "github",
@@ -15870,7 +15870,7 @@
     },
     "packages/storage": {
       "name": "@capacitor-firebase/storage",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "funding": [
         {
           "type": "github",

--- a/packages/firestore/src/definitions.ts
+++ b/packages/firestore/src/definitions.ts
@@ -246,7 +246,8 @@ export interface GetCollectionResult<T> {
    *
    * @since 5.2.0
    */
-  snapshots: QueryDocumentSnapshot<T>[];
+  // Replaced QueryDocumentSnapshot with DocumentSnapshot
+  snapshots: DocumentSnapshot<T>[];
 }
 
 /**
@@ -282,7 +283,7 @@ export interface GetCollectionGroupResult<T> {
    *
    * @since 5.2.0
    */
-  snapshots: QueryDocumentSnapshot<T>[];
+  snapshots: DocumentSnapshot<T>[];
 }
 
 /**
@@ -412,26 +413,26 @@ export interface DocumentSnapshot<T> {
 /**
  * @since 5.2.0
  */
-export interface QueryDocumentSnapshot<T> {
-  /**
-   * The document's identifier within its collection.
-   *
-   * @since 5.2.0
-   */
-  id: string;
-  /**
-   * The path of the document.
-   *
-   * @since 5.2.0
-   */
-  path: string;
-  /**
-   * An object containing the data for the document.
-   *
-   * @since 5.2.0
-   */
-  data: T;
-}
+// export interface QueryDocumentSnapshot<T> {
+//   /**
+//    * The document's identifier within its collection.
+//    *
+//    * @since 5.2.0
+//    */
+//   id: string;
+//   /**
+//    * The path of the document.
+//    *
+//    * @since 5.2.0
+//    */
+//   path: string;
+//   /**
+//    * An object containing the data for the document.
+//    *
+//    * @since 5.2.0
+//    */
+//   data: T | null;
+// }
 
 /**
  * @since 5.2.0


### PR DESCRIPTION
Issue: #510

Removed `QueryDocumentSnapshot` interface
Added `DocumentSnapshot` GetCollectionResult Interface

```diff

export interface GetCollectionResult<T> {
  /**
   * The documents in the collection.
   *
   * @since 5.2.0
   */
- snapshots: QueryDocumentSnapshot<T>[];
+ snapshots: DocumentSnapshot<T>[];
}


```