### PR TITLE
fix(authentication): sign-in with oauth provider failed

### DIFF
--- a/.changeset/fifty-eels-notice.md
+++ b/.changeset/fifty-eels-notice.md
@@ -2,4 +2,4 @@
 '@capacitor-firebase/authentication': minor
 ---
 
-Fix swapped link and signIn functions for oauth flow sign in
+fix(ios): sign-in with oauth provider failed

--- a/.changeset/fifty-eels-notice.md
+++ b/.changeset/fifty-eels-notice.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/authentication': minor
+---
+
+Fix swapped link and signIn functions for oauth flow sign in

--- a/.changeset/fifty-eels-notice.md
+++ b/.changeset/fifty-eels-notice.md
@@ -1,5 +1,5 @@
 ---
-'@capacitor-firebase/authentication': minor
+'@capacitor-firebase/authentication': patch
 ---
 
 fix(ios): sign-in with oauth provider failed

--- a/packages/authentication/ios/Plugin/Handlers/OAuthProviderHandler.swift
+++ b/packages/authentication/ios/Plugin/Handlers/OAuthProviderHandler.swift
@@ -53,8 +53,8 @@ class OAuthProviderHandler: NSObject {
                 return
             }
             if let credential = credential {
-                self.pluginImplementation.handleSuccessfulLink(credential: credential, idToken: nil, nonce: nil,
-                                                               accessToken: nil, serverAuthCode: nil, displayName: nil, authorizationCode: nil)
+                self.pluginImplementation.handleSuccessfulSignIn(credential: credential, idToken: nil, nonce: nil,
+                                                                 accessToken: nil, displayName: nil, authorizationCode: nil, serverAuthCode: nil)
             }
         }
     }
@@ -66,8 +66,8 @@ class OAuthProviderHandler: NSObject {
                 return
             }
             if let credential = credential {
-                self.pluginImplementation.handleSuccessfulSignIn(credential: credential, idToken: nil, nonce: nil,
-                                                                 accessToken: nil, displayName: nil, authorizationCode: nil, serverAuthCode: nil)
+                self.pluginImplementation.handleSuccessfulLink(credential: credential, idToken: nil, nonce: nil,
+                                                               accessToken: nil, serverAuthCode: nil, displayName: nil, authorizationCode: nil)
             }
         }
     }


### PR DESCRIPTION
Very simple change to fix swapped link and signIn functions for oauth flow sign in.

Close #524

Issue: 
Microsoft (and presumably other OAuth based sign in methods) were failing on iOS with a "No user signed in" error.
Swapping these functions as their names intend resolves the issue.

## Pull request checklist
Please check if your PR fulfills the following requirements:

- [X] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [ ] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).