### PR TITLE
fix(authentication): `authStateChange` event is not fired right after the listener is registered

### DIFF
--- a/.changeset/witty-clouds-yawn.md
+++ b/.changeset/witty-clouds-yawn.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/authentication': patch
+---
+
+fix: `authStateChange` event is not fired right after the listener is registered

--- a/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthentication.java
+++ b/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthentication.java
@@ -42,14 +42,6 @@ import java.util.List;
 import org.json.JSONObject;
 
 public class FirebaseAuthentication {
-
-    interface AuthStateChangeListener {
-        void onAuthStateChanged();
-    }
-
-    @Nullable
-    private AuthStateChangeListener authStateChangeListener;
-
     private FirebaseAuthenticationPlugin plugin;
     private FirebaseAuthenticationConfig config;
     private FirebaseAuth firebaseAuthInstance;
@@ -68,20 +60,9 @@ public class FirebaseAuthentication {
         this.initAuthProviderHandlers(config);
         this.firebaseAuthStateListener =
             firebaseAuth -> {
-                if (authStateChangeListener != null) {
-                    authStateChangeListener.onAuthStateChanged();
-                }
+                this.plugin.handleAuthStateChange();
             };
         firebaseAuthInstance.addAuthStateListener(this.firebaseAuthStateListener);
-    }
-
-    public void setAuthStateChangeListener(@Nullable AuthStateChangeListener listener) {
-        this.authStateChangeListener = listener;
-    }
-
-    @Nullable
-    public AuthStateChangeListener getAuthStateChangeListener() {
-        return authStateChangeListener;
     }
 
     public void applyActionCode(@NonNull String oobCode, @NonNull Runnable callback) {

--- a/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthentication.java
+++ b/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthentication.java
@@ -42,6 +42,7 @@ import java.util.List;
 import org.json.JSONObject;
 
 public class FirebaseAuthentication {
+
     private FirebaseAuthenticationPlugin plugin;
     private FirebaseAuthenticationConfig config;
     private FirebaseAuth firebaseAuthInstance;

--- a/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthenticationPlugin.java
+++ b/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthenticationPlugin.java
@@ -64,7 +64,6 @@ public class FirebaseAuthenticationPlugin extends Plugin {
     public void load() {
         config = getFirebaseAuthenticationConfig();
         implementation = new FirebaseAuthentication(this, config);
-        implementation.setAuthStateChangeListener(this::updateAuthState);
     }
 
     @PluginMethod
@@ -808,6 +807,14 @@ public class FirebaseAuthenticationPlugin extends Plugin {
         super.startActivityForResult(call, intent, callbackName);
     }
 
+    public void handleAuthStateChange() {
+        FirebaseUser user = implementation.getCurrentUser();
+        JSObject userResult = FirebaseAuthenticationHelper.createUserResult(user);
+        JSObject result = new JSObject();
+        result.put("user", (userResult == null ? JSONObject.NULL : userResult));
+        notifyListeners(AUTH_STATE_CHANGE_EVENT, result, true);
+    }
+
     @Override
     protected void handleOnActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         super.handleOnActivityResult(requestCode, resultCode, data);
@@ -815,14 +822,6 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             return;
         }
         implementation.handleOnActivityResult(requestCode, resultCode, data);
-    }
-
-    private void updateAuthState() {
-        FirebaseUser user = implementation.getCurrentUser();
-        JSObject userResult = FirebaseAuthenticationHelper.createUserResult(user);
-        JSObject result = new JSObject();
-        result.put("user", (userResult == null ? JSONObject.NULL : userResult));
-        notifyListeners(AUTH_STATE_CHANGE_EVENT, result, true);
     }
 
     @ActivityCallback

--- a/packages/authentication/ios/Plugin/FirebaseAuthentication.swift
+++ b/packages/authentication/ios/Plugin/FirebaseAuthentication.swift
@@ -7,7 +7,6 @@ public typealias AuthStateChangedObserver = () -> Void
 
 // swiftlint:disable type_body_length
 @objc public class FirebaseAuthentication: NSObject {
-    public var authStateObserver: AuthStateChangedObserver?
     private let plugin: FirebaseAuthenticationPlugin
     private let config: FirebaseAuthenticationConfig
     private var appleAuthProviderHandler: AppleAuthProviderHandler?
@@ -27,7 +26,7 @@ public typealias AuthStateChangedObserver = () -> Void
         }
         self.initAuthProviderHandlers(config: config)
         Auth.auth().addStateDidChangeListener {_, _ in
-            self.authStateObserver?()
+            self.plugin.handleAuthStateChange()
         }
     }
 

--- a/packages/authentication/ios/Plugin/FirebaseAuthenticationPlugin.swift
+++ b/packages/authentication/ios/Plugin/FirebaseAuthenticationPlugin.swift
@@ -41,9 +41,6 @@ public class FirebaseAuthenticationPlugin: CAPPlugin {
 
     override public func load() {
         self.implementation = FirebaseAuthentication(plugin: self, config: firebaseAuthenticationConfig())
-        self.implementation?.authStateObserver = { [weak self] in
-            self?.handleAuthStateChange()
-        }
     }
 
     @objc func applyActionCode(_ call: CAPPluginCall) {


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

Close #560 