### PR TITLE
Lose crashlytics runscript quotes

### DIFF
--- a/.changeset/five-dingos-wait.md
+++ b/.changeset/five-dingos-wait.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/crashlytics': patch
+---
+
+docs: take away quotes from ios runscript

--- a/packages/crashlytics/README.md
+++ b/packages/crashlytics/README.md
@@ -36,7 +36,7 @@ The following steps describe how to automatically upload dSYM files to Firebase 
    2. Expand the new **Run Script** section.
    3. In the script field (located under the *Shell* label), add the following run script:
       ```
-      "${PODS_ROOT}/FirebaseCrashlytics/run"
+      ${PODS_ROOT}/FirebaseCrashlytics/run
       ```
    4. In the Input Files section, add the paths for the locations of the following files:
       ```


### PR DESCRIPTION
Didn't work with quotes in xcode 15.3 anyways. Without, yes.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [✓] The changes have been tested successfully.
- [✓] A changeset has been created (`npm run changeset`).
- [ ] I have read✓ and followed× the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).
