### PR TITLE
fix(authentication): `authStateChange` listener fires too early on the web

### DIFF
--- a/.changeset/blue-bats-yell.md
+++ b/.changeset/blue-bats-yell.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/authentication': patch
+---
+
+fix(web): `authStateChange` listener fires too early

--- a/packages/authentication/src/web.ts
+++ b/packages/authentication/src/web.ts
@@ -719,6 +719,7 @@ export class FirebaseAuthenticationWeb
     this.notifyListeners(
       FirebaseAuthenticationWeb.AUTH_STATE_CHANGE_EVENT,
       change,
+      true,
     );
   }
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The changes have been tested successfully.
- [ ] A changeset has been created (`npm run changeset`).
- [ ] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).


Close #494