### PR TITLE
fix(authentication): `updateProfile(...)` ignored the `photoUrl`

### DIFF
--- a/.changeset/nasty-insects-turn.md
+++ b/.changeset/nasty-insects-turn.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/authentication': patch
+---
+
+fix(web): `updateProfile(...)` ignored the `photoUrl`

--- a/packages/authentication/src/web.ts
+++ b/packages/authentication/src/web.ts
@@ -732,7 +732,10 @@ export class FirebaseAuthenticationWeb
     if (!currentUser) {
       throw new Error(FirebaseAuthenticationWeb.ERROR_NO_USER_SIGNED_IN);
     }
-    return updateProfile(currentUser, options);
+    return updateProfile(currentUser, {
+      displayName: options.displayName,
+      photoURL: options.photoUrl,
+    });
   }
 
   public async useAppLanguage(): Promise<void> {


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The changes have been tested successfully.
- [ ] A changeset has been created (`npm run changeset`).
- [ ] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

Close #649 