### PR TITLE
fix(analytics): `setConsent(...)` method did not work

### DIFF
--- a/.changeset/perfect-lies-build.md
+++ b/.changeset/perfect-lies-build.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/analytics': patch
+---
+
+fix(analytics): Fixed setConsent signature issues

--- a/packages/analytics/ios/Plugin/FirebaseAnalyticsPlugin.swift
+++ b/packages/analytics/ios/Plugin/FirebaseAnalyticsPlugin.swift
@@ -32,11 +32,11 @@ public class FirebaseAnalyticsPlugin: CAPPlugin {
     }
 
     @objc func setConsent(_ call: CAPPluginCall) {
-        guard let consentType = FirebaseAnalyticsHelper.mapStringToConsentType(call.getString("consentType")) else {
+        guard let consentType = FirebaseAnalyticsHelper.mapStringToConsentType(call.getString("type")) else {
             call.reject(errorConsentTypeMissing)
             return
         }
-        guard let consentStatus = FirebaseAnalyticsHelper.mapStringToConsentStatus(call.getString("consentStatus")) else {
+        guard let consentStatus = FirebaseAnalyticsHelper.mapStringToConsentStatus(call.getString("status")) else {
             call.reject(errorConsentStatusMissing)
             return
         }


### PR DESCRIPTION
Closes https://github.com/capawesome-team/capacitor-firebase/issues/636

@robingenz one more update here. I forgot to fix the iOS parameter names.