### PR TITLE
feat(firestore): add timestamp & fieldvalue management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7600,7 +7600,7 @@
         "rimraf": "3.0.2",
         "rollup": "2.77.2",
         "swiftlint": "1.0.1",
-        "typescript": "4.1.5"
+        "typescript": "4.9.5"
       },
       "peerDependencies": {
         "@capacitor/core": "^6.0.0",
@@ -7622,6 +7622,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "packages/firestore/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "packages/functions": {

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestoreHelper.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestoreHelper.java
@@ -9,6 +9,7 @@ import io.capawesome.capacitorjs.plugins.firebase.firestore.classes.constraints.
 import io.capawesome.capacitorjs.plugins.firebase.firestore.classes.constraints.QueryLimitConstraint;
 import io.capawesome.capacitorjs.plugins.firebase.firestore.classes.constraints.QueryOrderByConstraint;
 import io.capawesome.capacitorjs.plugins.firebase.firestore.classes.constraints.QueryStartAtConstraint;
+import io.capawesome.capacitorjs.plugins.firebase.firestore.classes.fields.FirestoreField;
 import io.capawesome.capacitorjs.plugins.firebase.firestore.interfaces.QueryNonFilterConstraint;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -44,7 +45,7 @@ public class FirebaseFirestoreHelper {
             } else if (value instanceof Map) {
                 value = createJSObjectFromMap((Map<String, Object>) value);
             }
-            object.put(key, value);
+            object.put(key, parseObject(value));
         }
         return object;
     }
@@ -53,7 +54,7 @@ public class FirebaseFirestoreHelper {
         if (value.toString().equals("null")) {
             return null;
         } else if (value instanceof JSONObject) {
-            return createHashMapFromJSONObject((JSONObject) value);
+            return createObjectFromJSONObject((JSONObject) value);
         } else if (value instanceof JSONArray) {
             return createArrayListFromJSONArray((JSONArray) value);
         } else {
@@ -107,7 +108,7 @@ public class FirebaseFirestoreHelper {
         for (int x = 0; x < array.length(); x++) {
             Object value = array.get(x);
             if (value instanceof JSONObject) {
-                value = createHashMapFromJSONObject((JSONObject) value);
+                value = createObjectFromJSONObject((JSONObject) value);
             } else if (value instanceof JSONArray) {
                 value = createArrayListFromJSONArray((JSONArray) value);
             }
@@ -122,8 +123,28 @@ public class FirebaseFirestoreHelper {
             if (value instanceof Map) {
                 value = createJSObjectFromMap((Map<String, Object>) value);
             }
-            array.put(value);
+            array.put(parseObject(value));
         }
         return array;
+    }
+
+    private static Object createObjectFromJSONObject(@NonNull JSONObject object) throws JSONException {
+        if (FirestoreField.isFirestoreField(object)) {
+            FirestoreField field = FirestoreField.fromJSONObject(object);
+            return field.getField();
+        }
+
+        return createHashMapFromJSONObject(object);
+    }
+
+    /**
+     * Parse an object to return it's firestore field value. Else return the same object.
+     */
+    private static Object parseObject(@NonNull Object object) {
+        try {
+            return FirestoreField.fromObject(object).getJSObject();
+        } catch (Exception e) {}
+
+        return object;
     }
 }

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/fields/FieldValue.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/fields/FieldValue.java
@@ -1,0 +1,33 @@
+package io.capawesome.capacitorjs.plugins.firebase.firestore.classes.fields;
+
+import androidx.annotation.NonNull;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import io.capawesome.capacitorjs.plugins.firebase.firestore.enums.FieldValueMethod;
+
+public class FieldValue {
+
+    @NonNull
+    FieldValueMethod method;
+
+    public FieldValue(@NonNull FieldValueMethod method) {
+        this.method = method;
+    }
+
+    public static FieldValue fromJSONObject(@NonNull JSONObject value) throws JSONException {
+        return new FieldValue(
+            FieldValueMethod.fromString(value.getString("method"))
+        );
+    }
+
+    public Object getField() {
+        switch (method) {
+            case CREATE_SERVER_TIMESTAMP:
+                return com.google.firebase.firestore.FieldValue.serverTimestamp();
+            default:
+                return null;
+        }
+    }
+}

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/fields/FirestoreField.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/fields/FirestoreField.java
@@ -1,0 +1,71 @@
+package io.capawesome.capacitorjs.plugins.firebase.firestore.classes.fields;
+
+import androidx.annotation.NonNull;
+
+import com.getcapacitor.JSObject;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import io.capawesome.capacitorjs.plugins.firebase.firestore.enums.FirestoreFieldType;
+
+public class FirestoreField {
+
+    @NonNull
+    private FirestoreFieldType type;
+
+    @NonNull
+    private JSONObject value;
+
+    private static final String FIRESTORE_FIELD_TYPE = "_capacitorFirestoreFieldType";
+    private static final String FIRESTORE_FIELD_VALUE = "_capacitorFirestoreFieldValue";
+
+    /**
+     * Is a JSONObject a serialized Firestore field
+     * @param firestoreFieldData
+     * @return
+     */
+    public static boolean isFirestoreField(JSONObject firestoreFieldData) {
+        if (!firestoreFieldData.has(FIRESTORE_FIELD_TYPE)) {
+            return false;
+        }
+        return true;
+    }
+
+    public FirestoreField(FirestoreFieldType type, JSONObject value) {
+        this.type = type;
+        this.value = value;
+    }
+
+    public static FirestoreField fromJSONObject(JSONObject data) throws JSONException {
+        FirestoreFieldType type = FirestoreFieldType.fromString((String) data.get(FIRESTORE_FIELD_TYPE));
+        JSONObject value = (JSONObject) data.get(FIRESTORE_FIELD_VALUE);
+        return new FirestoreField(type, value);
+    }
+
+    public static FirestoreField fromObject(Object object) throws IllegalArgumentException {
+        if (object instanceof com.google.firebase.Timestamp) {
+            Timestamp timestamp = Timestamp.fromFirestore((com.google.firebase.Timestamp) object);
+            return new FirestoreField(FirestoreFieldType.TIMESTAMP, timestamp.getValue());
+        }
+        throw new IllegalArgumentException("The provided object is not a firestore field");
+    }
+
+    public Object getField() throws JSONException {
+        switch(type) {
+            case FIELD_VALUE:
+                return FieldValue.fromJSONObject(value).getField();
+            case TIMESTAMP:
+                return Timestamp.fromJSONObject(value).getField();
+            default:
+                return null;
+        }
+    }
+
+    public JSObject getJSObject() throws JSONException {
+        JSObject object = new JSObject();
+        object.put(FIRESTORE_FIELD_TYPE, type.toString());
+        object.put(FIRESTORE_FIELD_VALUE, JSObject.fromJSONObject(value));
+        return object;
+    }
+}

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/fields/Timestamp.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/fields/Timestamp.java
@@ -1,0 +1,51 @@
+package io.capawesome.capacitorjs.plugins.firebase.firestore.classes.fields;
+
+import androidx.annotation.NonNull;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class Timestamp {
+
+    @NonNull
+    long seconds;
+
+    @NonNull
+    int nanoseconds;
+
+    public Timestamp(@NonNull long seconds, @NonNull int nanoseconds) {
+        this.seconds = seconds;
+        this.nanoseconds = nanoseconds;
+    }
+
+    public static Timestamp fromJSONObject(@NonNull JSONObject value) throws JSONException {
+        return new Timestamp(
+            ((Number) value.get("seconds")).longValue(),
+            (int) value.get("nanoseconds")
+        );
+    }
+
+    public static Timestamp fromFirestore(@NonNull com.google.firebase.Timestamp timestamp) {
+        return new Timestamp(
+            timestamp.getSeconds(),
+            timestamp.getNanoseconds()
+        );
+    }
+
+    @NonNull
+    public JSONObject getValue() {
+        JSONObject value = new JSONObject();
+        try {
+            value.put("seconds", seconds);
+            value.put("nanoseconds", nanoseconds);
+        } catch (JSONException e) {}
+        return value;
+    }
+
+    public com.google.firebase.Timestamp getField() throws JSONException {
+        return new com.google.firebase.Timestamp(
+            seconds,
+            nanoseconds
+        );
+    }
+}

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/enums/FieldValueMethod.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/enums/FieldValueMethod.java
@@ -1,0 +1,26 @@
+package io.capawesome.capacitorjs.plugins.firebase.firestore.enums;
+
+public enum FieldValueMethod {
+    CREATE_SERVER_TIMESTAMP("serverTimestamp");
+
+    private String value;
+
+    private FieldValueMethod(String value) {
+        this.value = value;
+    }
+
+    private String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return this.getValue();
+    }
+
+    public static FieldValueMethod fromString(String value) {
+        for(FieldValueMethod v : values())
+            if(v.getValue().equalsIgnoreCase(value)) return v;
+        throw new IllegalArgumentException();
+    }
+}

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/enums/FirestoreFieldType.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/enums/FirestoreFieldType.java
@@ -1,0 +1,27 @@
+package io.capawesome.capacitorjs.plugins.firebase.firestore.enums;
+
+public enum FirestoreFieldType {
+    FIELD_VALUE("fieldvalue"),
+    TIMESTAMP("timestamp");
+
+    private String value;
+
+    private FirestoreFieldType(String value) {
+        this.value = value;
+    }
+
+    private String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return this.getValue();
+    }
+
+    public static FirestoreFieldType fromString(String value) {
+        for(FirestoreFieldType v : values())
+            if(v.getValue().equalsIgnoreCase(value)) return v;
+        throw new IllegalArgumentException();
+    }
+}

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -70,7 +70,7 @@
     "rimraf": "3.0.2",
     "rollup": "2.77.2",
     "swiftlint": "1.0.1",
-    "typescript": "4.1.5"
+    "typescript": "4.9.5"
   },
   "peerDependencies": {
     "@capacitor/core": "^6.0.0",

--- a/packages/firestore/src/client.ts
+++ b/packages/firestore/src/client.ts
@@ -1,0 +1,102 @@
+import { Timestamp as OriginalTimestamp } from 'firebase/firestore';
+
+import type { DocumentSnapshot, FirebaseFirestorePlugin } from './definitions';
+import type { CustomField } from './internals';
+import { FIRESTORE_FIELD_TYPE, FIRESTORE_FIELD_VALUE } from './internals';
+import { Timestamp } from './timestamp';
+
+/**
+ * Apply a proxy on the plugin to manage document data parsing
+ * @param plugin The capacitor plugin
+ * @returns A proxied plugin that manage parsing
+ */
+export function getClientPlugin(
+  plugin: FirebaseFirestorePlugin,
+): FirebaseFirestorePlugin {
+  return new Proxy(plugin, {
+    get(target, prop) {
+      // Get document, collection or collection group
+      if (
+        prop === 'getDocument' ||
+        prop === 'getCollection' ||
+        prop === 'getCollectionGroup'
+      ) {
+        return async function (options: any): Promise<any> {
+          return parseResult(await (target[prop] as any)(options));
+        };
+      }
+
+      // Listener document, collection, collection group
+      if (
+        prop === 'addDocumentSnapshotListener' ||
+        prop === 'addCollectionSnapshotListener' ||
+        prop === 'addCollectionGroupSnapshotListener'
+      ) {
+        return async function (options: any, callback: any): Promise<any> {
+          return (target[prop] as any)(options, (ev: any, err: any) =>
+            callback(ev ? parseResult(ev as any) : ev, err),
+          );
+        };
+      }
+
+      return (target as any)[prop];
+    },
+  });
+}
+
+/**
+ * Parse a received result
+ * @param res The result of a read method
+ * @returns The parsed result
+ */
+function parseResult<
+  T,
+  U extends {
+    snapshot?: DocumentSnapshot<T>;
+    snapshots?: DocumentSnapshot<T>[];
+  },
+>(res: U): U {
+  if (res?.snapshot?.data) {
+    res.snapshot.data = parseResultDocumentData(res.snapshot.data);
+  }
+  if (res?.snapshots) {
+    res.snapshots.map(s => parseResultDocumentData(s));
+  }
+  return res;
+}
+
+/**
+ * Parse the document data result to convert some field values
+ * @param data The document data to parse
+ * @returns
+ */
+function parseResultDocumentData(data: any): any {
+  if (!data) {
+    return data;
+  }
+
+  // On web, convert the firebase Timestamp into the custom one
+  if (data instanceof OriginalTimestamp) {
+    return Timestamp.fromOriginalTimestamp(data);
+  }
+
+  // On native, we receive the special JSON format to convert
+  if (data[FIRESTORE_FIELD_TYPE]) {
+    const field: CustomField = data;
+    switch (field[FIRESTORE_FIELD_TYPE]) {
+      case 'timestamp':
+        return new Timestamp(
+          field[FIRESTORE_FIELD_VALUE].seconds,
+          field[FIRESTORE_FIELD_VALUE].nanoseconds,
+        );
+    }
+  }
+
+  if (typeof data === 'object') {
+    Object.keys(data).forEach(key => {
+      data[key] = parseResultDocumentData(data[key]);
+    });
+  }
+
+  return data;
+}

--- a/packages/firestore/src/field-value.ts
+++ b/packages/firestore/src/field-value.ts
@@ -1,0 +1,21 @@
+import type { FieldValue as OriginalFieldValue } from 'firebase/firestore';
+import { serverTimestamp as originalServerTimestamp } from 'firebase/firestore';
+
+import type { CustomField } from './internals';
+import { FIRESTORE_FIELD_TYPE, FIRESTORE_FIELD_VALUE } from './internals';
+
+type FieldValue = OriginalFieldValue & { toJSON?: () => any };
+
+export function serverTimestamp(
+  ...args: Parameters<typeof originalServerTimestamp>
+): OriginalFieldValue {
+  const fieldValue: FieldValue = originalServerTimestamp(...args);
+  fieldValue.toJSON = () =>
+    ({
+      [FIRESTORE_FIELD_TYPE]: 'fieldvalue',
+      [FIRESTORE_FIELD_VALUE]: {
+        method: 'serverTimestamp',
+      },
+    } as CustomField);
+  return fieldValue;
+}

--- a/packages/firestore/src/index.ts
+++ b/packages/firestore/src/index.ts
@@ -1,13 +1,15 @@
 import { registerPlugin } from '@capacitor/core';
 
+import { getClientPlugin } from './client';
 import type { FirebaseFirestorePlugin } from './definitions';
 
-const FirebaseFirestore = registerPlugin<FirebaseFirestorePlugin>(
-  'FirebaseFirestore',
-  {
+const FirebaseFirestore = getClientPlugin(
+  registerPlugin<FirebaseFirestorePlugin>('FirebaseFirestore', {
     web: () => import('./web').then(m => new m.FirebaseFirestoreWeb()),
-  },
+  }),
 );
 
 export * from './definitions';
+export * from './timestamp';
+export * from './field-value';
 export { FirebaseFirestore };

--- a/packages/firestore/src/internals.ts
+++ b/packages/firestore/src/internals.ts
@@ -1,0 +1,28 @@
+/**
+ * The custom field type attribute key
+ */
+export const FIRESTORE_FIELD_TYPE = '_capacitorFirestoreFieldType';
+
+/**
+ * The custom field value attribute key
+ */
+export const FIRESTORE_FIELD_VALUE = '_capacitorFirestoreFieldValue';
+
+/**
+ * A firestore document data custom field
+ * Used to serialize the special Firestore fields into JSON
+ */
+export type CustomField =
+  | {
+      [FIRESTORE_FIELD_TYPE]: 'fieldvalue';
+      [FIRESTORE_FIELD_VALUE]: {
+        method: string;
+      };
+    }
+  | {
+      [FIRESTORE_FIELD_TYPE]: 'timestamp';
+      [FIRESTORE_FIELD_VALUE]: {
+        seconds: number;
+        nanoseconds: number;
+      };
+    };

--- a/packages/firestore/src/timestamp.ts
+++ b/packages/firestore/src/timestamp.ts
@@ -1,0 +1,40 @@
+import { Timestamp as OriginalTimestamp } from 'firebase/firestore';
+
+import type { CustomField } from './internals';
+import { FIRESTORE_FIELD_TYPE, FIRESTORE_FIELD_VALUE } from './internals';
+
+export class Timestamp extends OriginalTimestamp {
+  /**
+   * Creates a new timestamp from a JS SDK firestore timestamp.
+   *
+   * @param timestamp The Firestore timestamp.
+   * @returns A new `Timestamp` representing the same point in time as the given timestamp.
+   */
+  public static fromOriginalTimestamp(timestamp: OriginalTimestamp): Timestamp {
+    return new Timestamp(timestamp.seconds, timestamp.nanoseconds);
+  }
+
+  static now(): Timestamp {
+    return Timestamp.fromOriginalTimestamp(OriginalTimestamp.now());
+  }
+
+  static fromDate(date: Date): Timestamp {
+    return Timestamp.fromOriginalTimestamp(OriginalTimestamp.fromDate(date));
+  }
+
+  static fromMillis(milliseconds: number): Timestamp {
+    return Timestamp.fromOriginalTimestamp(
+      OriginalTimestamp.fromMillis(milliseconds),
+    );
+  }
+
+  public toJSON(): any {
+    return {
+      [FIRESTORE_FIELD_TYPE]: 'timestamp',
+      [FIRESTORE_FIELD_VALUE]: {
+        seconds: this.seconds,
+        nanoseconds: this.nanoseconds,
+      },
+    } as CustomField;
+  }
+}


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The changes have been tested successfully.
- [ ] A changeset has been created (`npm run changeset`).
- [ ] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

Close #474, #443 

Linked PR: #557

Usage example:
```ts
import { FirebaseFirestore, Timestamp, serverTimestamp } from "@capacitor-firebase/firestore";

FirebaseFirestore.setDocument({
    reference: "collection/doc",
    data: {
      timestamp: Timestamp.now(),
      fieldValue: serverTimestamp()
    },
 });
```