### PR TITLE
Changed the analytics version of the documentation from 21.2.2 to 21.5.1

### DIFF
--- a/.changeset/slow-news-poke.md
+++ b/.changeset/slow-news-poke.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/analytics': patch
+---
+
+Changed the analytics version of the documentation from 21.2.2 to 21.5.1

--- a/.changeset/slow-news-poke.md
+++ b/.changeset/slow-news-poke.md
@@ -1,5 +1,0 @@
----
-'@capacitor-firebase/analytics': patch
----
-
-Changed the analytics version of the documentation from 21.2.2 to 21.5.1

--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -25,7 +25,7 @@ See [Disable Advertising ID collection](https://firebase.google.com/docs/analyti
 
 This plugin will use the following project variables (defined in your app’s `variables.gradle` file):
 
-- `$firebaseAnalyticsVersion` version of `com.google.firebase:firebase-analytics` (default: `21.2.2`)
+- `$firebaseAnalyticsVersion` version of `com.google.firebase:firebase-analytics` (default: `21.5.1`)
 
 ### iOS
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).


If you keep the old version of firebaseAnalyticsVersion = '21.2.2' in the new Capacitor 6 version it gives an error when compiling.

By default the new version of Firebase Analytics is now firebaseAnalyticsVersion = '21.5.1' but you should update it in the documentation so that you don't get an error when upgrading.

<img width="1303" alt="firebase_analytics_error" src="https://github.com/user-attachments/assets/281b5e09-0b1f-4d1a-a5c7-02c726e477a3">

Fix: #679