### PR TITLE
feat(remote-config): add `setSettings(...)` method

### DIFF
--- a/.changeset/soft-news-flash.md
+++ b/.changeset/soft-news-flash.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/remote-config': minor
+---
+
+feat: add setConfigSettings method

--- a/.changeset/soft-news-flash.md
+++ b/.changeset/soft-news-flash.md
@@ -2,4 +2,4 @@
 '@capacitor-firebase/remote-config': minor
 ---
 
-feat: add setConfigSettings method
+feat: add `setSettings(...)` method

--- a/packages/remote-config/README.md
+++ b/packages/remote-config/README.md
@@ -257,8 +257,8 @@ setSettings(options: SetSettingsOptions) => Promise<void>
 
 Set the remote config settings.
 
-| Param         | Type                                                                          |
-| ------------- | ----------------------------------------------------------------------------- |
+| Param         | Type                                                              |
+| ------------- | ----------------------------------------------------------------- |
 | **`options`** | <code><a href="#setsettingsoptions">SetSettingsOptions</a></code> |
 
 **Since:** 6.2.0

--- a/packages/remote-config/README.md
+++ b/packages/remote-config/README.md
@@ -257,8 +257,7 @@ setSettings(options: SetSettingsOptions) => Promise<void>
 
 Set the remote config settings.
 
-On Android, the settings values are saved in SharedPreferences.
-Therefore, please note that even if setSettings is removed, the saved values will still be used.
+On Android, the settings values are persisted in SharedPreferences.
 
 | Param         | Type                                                              |
 | ------------- | ----------------------------------------------------------------- |

--- a/packages/remote-config/README.md
+++ b/packages/remote-config/README.md
@@ -110,6 +110,7 @@ const removeAllListeners = async () => {
 * [`getNumber(...)`](#getnumber)
 * [`getString(...)`](#getstring)
 * [`setMinimumFetchInterval(...)`](#setminimumfetchinterval)
+* [`setConfigSettings(...)`](#setconfigsettings)
 * [`addConfigUpdateListener(...)`](#addconfigupdatelistener)
 * [`removeConfigUpdateListener(...)`](#removeconfigupdatelistener)
 * [`removeAllListeners()`](#removealllisteners)
@@ -241,6 +242,23 @@ Only available for Web.
 --------------------
 
 
+### setConfigSettings(...)
+
+```typescript
+setConfigSettings(options: SetConfigSettingsOptions) => Promise<void>
+```
+
+Set the remote config settings.
+
+| Param         | Type                                                                          |
+| ------------- | ----------------------------------------------------------------------------- |
+| **`options`** | <code><a href="#setconfigsettingsoptions">SetConfigSettingsOptions</a></code> |
+
+**Since:** 6.2.0
+
+--------------------
+
+
 ### addConfigUpdateListener(...)
 
 ```typescript
@@ -340,6 +358,14 @@ Remove all listeners for this plugin.
 | Prop                                | Type                | Description                                                                                                                                                                           | Default            | Since |
 | ----------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ----- |
 | **`minimumFetchIntervalInSeconds`** | <code>number</code> | Define the maximum age in seconds of an entry in the config cache before it is considered stale. During development, it's recommended to set a relatively low minimum fetch interval. | <code>43200</code> | 1.3.0 |
+
+
+#### SetConfigSettingsOptions
+
+| Prop                                | Type                | Description                                                                                                                                                                           | Default            | Since |
+| ----------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ----- |
+| **`fetchTimeoutInSeconds`**         | <code>number</code> | Defines the maximum amount of milliseconds to wait for a response when fetching configuration from the Remote Config server.                                                          | <code>60</code>    | 6.2.0 |
+| **`minimumFetchIntervalInSeconds`** | <code>number</code> | Define the maximum age in seconds of an entry in the config cache before it is considered stale. During development, it's recommended to set a relatively low minimum fetch interval. | <code>43200</code> | 6.2.0 |
 
 
 #### AddConfigUpdateListenerOptionsCallbackEvent

--- a/packages/remote-config/README.md
+++ b/packages/remote-config/README.md
@@ -75,6 +75,13 @@ const getString = async () => {
   return value;
 };
 
+const setConfigSettings = async () => {
+  await FirebaseRemoteConfig.setConfigSettings({
+    fetchTimeoutInSeconds: 10,
+    minimumFetchIntervalInSeconds: 0,
+  });
+};
+
 const addConfigUpdateListener = async () => {
   const callbackId = await FirebaseRemoteConfig.addConfigUpdateListener(
     (event, error) => {

--- a/packages/remote-config/README.md
+++ b/packages/remote-config/README.md
@@ -257,6 +257,9 @@ setSettings(options: SetSettingsOptions) => Promise<void>
 
 Set the remote config settings.
 
+On Android, the settings values are saved in SharedPreferences.
+Therefore, please note that even if setSettings is removed, the saved values will still be used.
+
 | Param         | Type                                                              |
 | ------------- | ----------------------------------------------------------------- |
 | **`options`** | <code><a href="#setsettingsoptions">SetSettingsOptions</a></code> |

--- a/packages/remote-config/README.md
+++ b/packages/remote-config/README.md
@@ -75,8 +75,8 @@ const getString = async () => {
   return value;
 };
 
-const setConfigSettings = async () => {
-  await FirebaseRemoteConfig.setConfigSettings({
+const setSettings = async () => {
+  await FirebaseRemoteConfig.setSettings({
     fetchTimeoutInSeconds: 10,
     minimumFetchIntervalInSeconds: 0,
   });
@@ -117,7 +117,7 @@ const removeAllListeners = async () => {
 * [`getNumber(...)`](#getnumber)
 * [`getString(...)`](#getstring)
 * [`setMinimumFetchInterval(...)`](#setminimumfetchinterval)
-* [`setConfigSettings(...)`](#setconfigsettings)
+* [`setSettings(...)`](#setsettings)
 * [`addConfigUpdateListener(...)`](#addconfigupdatelistener)
 * [`removeConfigUpdateListener(...)`](#removeconfigupdatelistener)
 * [`removeAllListeners()`](#removealllisteners)
@@ -249,17 +249,17 @@ Only available for Web.
 --------------------
 
 
-### setConfigSettings(...)
+### setSettings(...)
 
 ```typescript
-setConfigSettings(options: SetConfigSettingsOptions) => Promise<void>
+setSettings(options: SetSettingsOptions) => Promise<void>
 ```
 
 Set the remote config settings.
 
 | Param         | Type                                                                          |
 | ------------- | ----------------------------------------------------------------------------- |
-| **`options`** | <code><a href="#setconfigsettingsoptions">SetConfigSettingsOptions</a></code> |
+| **`options`** | <code><a href="#setsettingsoptions">SetSettingsOptions</a></code> |
 
 **Since:** 6.2.0
 
@@ -367,7 +367,7 @@ Remove all listeners for this plugin.
 | **`minimumFetchIntervalInSeconds`** | <code>number</code> | Define the maximum age in seconds of an entry in the config cache before it is considered stale. During development, it's recommended to set a relatively low minimum fetch interval. | <code>43200</code> | 1.3.0 |
 
 
-#### SetConfigSettingsOptions
+#### SetSettingsOptions
 
 | Prop                                | Type                | Description                                                                                                                                                                           | Default            | Since |
 | ----------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ----- |

--- a/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -93,7 +93,7 @@ public class FirebaseRemoteConfig {
         return new GetValueResult<String>(value.asString(), value.getSource());
     }
 
-    public Task<Void> setConfigSettings(@Nullable Integer fetchTimeoutInSeconds, @Nullable Integer minimumFetchIntervalInSeconds) {
+    public Task<Void> setSettings(@Nullable Integer fetchTimeoutInSeconds, @Nullable Integer minimumFetchIntervalInSeconds) {
         FirebaseRemoteConfigSettings.Builder builder = new FirebaseRemoteConfigSettings.Builder();
         if (fetchTimeoutInSeconds != null) {
             builder.setFetchTimeoutInSeconds(fetchTimeoutInSeconds);

--- a/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -4,7 +4,7 @@ import static io.capawesome.capacitorjs.plugins.firebase.remoteconfig.FirebaseRe
 
 import android.util.Log;
 import androidx.annotation.NonNull;
-import com.google.android.gms.tasks.OnCompleteListener;
+
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.remoteconfig.ConfigUpdate;
 import com.google.firebase.remoteconfig.ConfigUpdateListener;

--- a/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -62,22 +62,6 @@ public class FirebaseRemoteConfig {
             );
     }
 
-    public void fetchConfig(final FetchConfigResultCallback resultCallback) {
-        getFirebaseRemoteConfigInstance()
-                .fetch()
-                .addOnSuccessListener(
-                        result -> {
-                            resultCallback.success();
-                        }
-                )
-                .addOnFailureListener(
-                        exception -> {
-                            Log.w(TAG, "Fetch config failed.", exception);
-                            resultCallback.error(exception.getMessage());
-                        }
-                );
-    }
-
     public void fetchConfig(long minimumFetchIntervalInSeconds, final FetchConfigResultCallback resultCallback) {
         getFirebaseRemoteConfigInstance()
             .fetch(minimumFetchIntervalInSeconds)

--- a/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -10,6 +10,7 @@ import com.google.firebase.remoteconfig.ConfigUpdate;
 import com.google.firebase.remoteconfig.ConfigUpdateListener;
 import com.google.firebase.remoteconfig.ConfigUpdateListenerRegistration;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigException;
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigValue;
 import io.capawesome.capacitorjs.plugins.firebase.remoteconfig.classes.events.AddConfigUpdateListenerOptionsCallbackEvent;
 import io.capawesome.capacitorjs.plugins.firebase.remoteconfig.classes.options.AddConfigUpdateListenerOptions;
@@ -89,6 +90,12 @@ public class FirebaseRemoteConfig {
     public GetValueResult<String> getString(String key) {
         FirebaseRemoteConfigValue value = getFirebaseRemoteConfigInstance().getValue(key);
         return new GetValueResult<String>(value.asString(), value.getSource());
+    }
+
+    public Task<Void> setFetchTimeout(@NonNull long fetchTimeoutInSeconds) {
+        FirebaseRemoteConfigSettings.Builder builder = new FirebaseRemoteConfigSettings.Builder();
+        builder.setFetchTimeoutInSeconds(fetchTimeoutInSeconds);
+        return getFirebaseRemoteConfigInstance().setConfigSettingsAsync(builder.build());
     }
 
     public void addConfigUpdateListener(@NonNull AddConfigUpdateListenerOptions options, @NonNull NonEmptyResultCallback callback) {

--- a/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -62,6 +62,22 @@ public class FirebaseRemoteConfig {
             );
     }
 
+    public void fetchConfig(final FetchConfigResultCallback resultCallback) {
+        getFirebaseRemoteConfigInstance()
+                .fetch()
+                .addOnSuccessListener(
+                        result -> {
+                            resultCallback.success();
+                        }
+                )
+                .addOnFailureListener(
+                        exception -> {
+                            Log.w(TAG, "Fetch config failed.", exception);
+                            resultCallback.error(exception.getMessage());
+                        }
+                );
+    }
+
     public void fetchConfig(long minimumFetchIntervalInSeconds, final FetchConfigResultCallback resultCallback) {
         getFirebaseRemoteConfigInstance()
             .fetch(minimumFetchIntervalInSeconds)

--- a/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -5,7 +5,6 @@ import static io.capawesome.capacitorjs.plugins.firebase.remoteconfig.FirebaseRe
 import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.remoteconfig.ConfigUpdate;
 import com.google.firebase.remoteconfig.ConfigUpdateListener;

--- a/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -4,6 +4,7 @@ import static io.capawesome.capacitorjs.plugins.firebase.remoteconfig.FirebaseRe
 
 import android.util.Log;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.remoteconfig.ConfigUpdate;
@@ -92,10 +93,14 @@ public class FirebaseRemoteConfig {
         return new GetValueResult<String>(value.asString(), value.getSource());
     }
 
-    public Task<Void> setConfigSettings(@NonNull long fetchTimeoutInSeconds, @NonNull long minimumFetchIntervalInSeconds) {
+    public Task<Void> setConfigSettings(@Nullable Integer fetchTimeoutInSeconds, @Nullable Integer minimumFetchIntervalInSeconds) {
         FirebaseRemoteConfigSettings.Builder builder = new FirebaseRemoteConfigSettings.Builder();
-        builder.setFetchTimeoutInSeconds(fetchTimeoutInSeconds);
-        builder.setMinimumFetchIntervalInSeconds(minimumFetchIntervalInSeconds);
+        if (fetchTimeoutInSeconds != null) {
+            builder.setFetchTimeoutInSeconds(fetchTimeoutInSeconds);
+        }
+        if (minimumFetchIntervalInSeconds != null) {
+            builder.setMinimumFetchIntervalInSeconds(minimumFetchIntervalInSeconds);
+        }
         return getFirebaseRemoteConfigInstance().setConfigSettingsAsync(builder.build());
     }
 

--- a/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -92,9 +92,10 @@ public class FirebaseRemoteConfig {
         return new GetValueResult<String>(value.asString(), value.getSource());
     }
 
-    public Task<Void> setFetchTimeout(@NonNull long fetchTimeoutInSeconds) {
+    public Task<Void> setConfigSettings(@NonNull long fetchTimeoutInSeconds, @NonNull long minimumFetchIntervalInSeconds) {
         FirebaseRemoteConfigSettings.Builder builder = new FirebaseRemoteConfigSettings.Builder();
         builder.setFetchTimeoutInSeconds(fetchTimeoutInSeconds);
+        builder.setMinimumFetchIntervalInSeconds(minimumFetchIntervalInSeconds);
         return getFirebaseRemoteConfigInstance().setConfigSettingsAsync(builder.build());
     }
 

--- a/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
+++ b/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
@@ -6,7 +6,6 @@ import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
-
 import io.capawesome.capacitorjs.plugins.firebase.remoteconfig.classes.options.AddConfigUpdateListenerOptions;
 import io.capawesome.capacitorjs.plugins.firebase.remoteconfig.classes.options.RemoveConfigUpdateListenerOptions;
 import io.capawesome.capacitorjs.plugins.firebase.remoteconfig.interfaces.NonEmptyResultCallback;

--- a/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
+++ b/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
@@ -80,22 +80,23 @@ public class FirebaseRemoteConfigPlugin extends Plugin {
     public void fetchConfig(PluginCall call) {
         try {
             Integer minimumFetchIntervalInSeconds = call.getInt("minimumFetchIntervalInSeconds");
-            FetchConfigResultCallback callback = new FetchConfigResultCallback() {
-                @Override
-                public void success() {
-                    call.resolve();
-                }
-
-                @Override
-                public void error(String message) {
-                    call.reject(message);
-                }
-            };
             if (minimumFetchIntervalInSeconds == null) {
-                implementation.fetchConfig(callback);
-            } else {
-                implementation.fetchConfig(minimumFetchIntervalInSeconds.longValue(), callback);
+                minimumFetchIntervalInSeconds = DEFAULT_MINIMUM_FETCH_INTERVAL_IN_SECONDS;
             }
+            implementation.fetchConfig(
+                minimumFetchIntervalInSeconds.longValue(),
+                new FetchConfigResultCallback() {
+                    @Override
+                    public void success() {
+                        call.resolve();
+                    }
+
+                    @Override
+                    public void error(String message) {
+                        call.reject(message);
+                    }
+                }
+            );
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
             call.reject(exception.getMessage());

--- a/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
+++ b/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
@@ -166,7 +166,7 @@ public class FirebaseRemoteConfigPlugin extends Plugin {
 
     @PluginMethod
     public void setMinimumFetchInterval(PluginCall call) {
-        call.reject("Not available on Android. Use setConfigSettings.");
+        call.reject("Not available on Android.");
     }
 
     @PluginMethod

--- a/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
+++ b/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
@@ -172,21 +172,14 @@ public class FirebaseRemoteConfigPlugin extends Plugin {
     @PluginMethod
     public void setConfigSettings(PluginCall call) {
         try {
-            Integer fetchTimeoutInSeconds = call.getInt("fetchTimeoutInSeconds");
-            if (fetchTimeoutInSeconds == null) {
-                fetchTimeoutInSeconds = DEFAULT_FETCH_TIMEOUT_IN_SECONDS;
-            }
-            Integer minimumFetchIntervalInSeconds = call.getInt("minimumFetchIntervalInSeconds");
-            if (minimumFetchIntervalInSeconds == null) {
-                minimumFetchIntervalInSeconds = DEFAULT_MINIMUM_FETCH_INTERVAL_IN_SECONDS;
-            }
-            
-            final Integer finalMinimumFetchIntervalInSeconds = minimumFetchIntervalInSeconds; // To use in lambda expression
+            Integer fetchTimeoutInSeconds = call.getInt("fetchTimeoutInSeconds", DEFAULT_FETCH_TIMEOUT_IN_SECONDS);
+            Integer minimumFetchIntervalInSeconds = call.getInt("minimumFetchIntervalInSeconds", DEFAULT_MINIMUM_FETCH_INTERVAL_IN_SECONDS);
+
             implementation.setConfigSettings(fetchTimeoutInSeconds, minimumFetchIntervalInSeconds)
                 .addOnCompleteListener(t -> {
                     // NOTE: Android remote config sdk does not have an interface to get setting value.
                     // Therefore, the minimumFetchIntervalInSeconds is stored in a property of this class.
-                    this.customMinimumFetchIntervalInSeconds = finalMinimumFetchIntervalInSeconds;
+                    this.customMinimumFetchIntervalInSeconds = minimumFetchIntervalInSeconds;
                     call.resolve();
                 });
         } catch (Exception exception) {

--- a/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
+++ b/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
@@ -80,9 +80,6 @@ public class FirebaseRemoteConfigPlugin extends Plugin {
     public void fetchConfig(PluginCall call) {
         try {
             Integer minimumFetchIntervalInSeconds = call.getInt("minimumFetchIntervalInSeconds", DEFAULT_MINIMUM_FETCH_INTERVAL_IN_SECONDS);
-            if (minimumFetchIntervalInSeconds == null) {
-                minimumFetchIntervalInSeconds = DEFAULT_MINIMUM_FETCH_INTERVAL_IN_SECONDS;
-            }
             implementation.fetchConfig(
                 minimumFetchIntervalInSeconds.longValue(),
                 new FetchConfigResultCallback() {

--- a/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
+++ b/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
@@ -168,10 +168,13 @@ public class FirebaseRemoteConfigPlugin extends Plugin {
             Integer fetchTimeoutInSeconds = call.getInt("fetchTimeoutInSeconds", DEFAULT_FETCH_TIMEOUT_IN_SECONDS);
             Integer minimumFetchIntervalInSeconds = call.getInt("minimumFetchIntervalInSeconds", DEFAULT_MINIMUM_FETCH_INTERVAL_IN_SECONDS);
 
-            implementation.setSettings(fetchTimeoutInSeconds, minimumFetchIntervalInSeconds)
-                .addOnCompleteListener(t -> {
-                    call.resolve();
-                });
+            implementation
+                .setSettings(fetchTimeoutInSeconds, minimumFetchIntervalInSeconds)
+                .addOnCompleteListener(
+                    t -> {
+                        call.resolve();
+                    }
+                );
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);
             call.reject(exception.getMessage());

--- a/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
+++ b/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
@@ -170,12 +170,12 @@ public class FirebaseRemoteConfigPlugin extends Plugin {
     }
 
     @PluginMethod
-    public void setConfigSettings(PluginCall call) {
+    public void setSettings(PluginCall call) {
         try {
             Integer fetchTimeoutInSeconds = call.getInt("fetchTimeoutInSeconds", DEFAULT_FETCH_TIMEOUT_IN_SECONDS);
             Integer minimumFetchIntervalInSeconds = call.getInt("minimumFetchIntervalInSeconds", DEFAULT_MINIMUM_FETCH_INTERVAL_IN_SECONDS);
 
-            implementation.setConfigSettings(fetchTimeoutInSeconds, minimumFetchIntervalInSeconds)
+            implementation.setSettings(fetchTimeoutInSeconds, minimumFetchIntervalInSeconds)
                 .addOnCompleteListener(t -> {
                     // NOTE: Android remote config sdk does not have an interface to get setting value.
                     // Therefore, the minimumFetchIntervalInSeconds is stored in a property of this class.

--- a/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
+++ b/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
@@ -79,7 +79,7 @@ public class FirebaseRemoteConfigPlugin extends Plugin {
     @PluginMethod
     public void fetchConfig(PluginCall call) {
         try {
-            Integer minimumFetchIntervalInSeconds = call.getInt("minimumFetchIntervalInSeconds");
+            Integer minimumFetchIntervalInSeconds = call.getInt("minimumFetchIntervalInSeconds", DEFAULT_MINIMUM_FETCH_INTERVAL_IN_SECONDS);
             if (minimumFetchIntervalInSeconds == null) {
                 minimumFetchIntervalInSeconds = DEFAULT_MINIMUM_FETCH_INTERVAL_IN_SECONDS;
             }

--- a/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
+++ b/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
@@ -162,24 +162,23 @@ public class FirebaseRemoteConfigPlugin extends Plugin {
 
     @PluginMethod
     public void setMinimumFetchInterval(PluginCall call) {
-        call.reject("Not available on Android.");
+        call.reject("Not available on Android. Use setConfigSettings.");
     }
 
     @PluginMethod
-    public void setFetchTimeout(PluginCall call) {
+    public void setConfigSettings(PluginCall call) {
         try {
-            int fetchTimeoutInSeconds = call.getInt("fetchTimeoutInSeconds", -1);
-            if (fetchTimeoutInSeconds == -1) {
-                call.reject("fetchTimeoutInSeconds must be provided.");
-            }
-            Task<Void> task = implementation.setFetchTimeout(fetchTimeoutInSeconds);
+            int fetchTimeoutInSeconds = call.getInt("fetchTimeoutInSeconds", 60);
+            int minimumFetchIntervalInSeconds = call.getInt("minimumFetchIntervalInSeconds", 43200);
+
+            Task<Void> task = implementation.setConfigSettings(fetchTimeoutInSeconds, minimumFetchIntervalInSeconds);
             task.addOnCompleteListener(
-                new OnCompleteListener<Void>() {
-                    @Override
-                    public void onComplete(@NonNull Task<Void> task) {
-                        call.resolve();
+                    new OnCompleteListener<Void>() {
+                        @Override
+                        public void onComplete(@NonNull Task<Void> task) {
+                            call.resolve();
+                        }
                     }
-                }
             );
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);

--- a/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
+++ b/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
@@ -1,11 +1,16 @@
 package io.capawesome.capacitorjs.plugins.firebase.remoteconfig;
 
+import androidx.annotation.NonNull;
+
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Logger;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+
 import io.capawesome.capacitorjs.plugins.firebase.remoteconfig.classes.options.AddConfigUpdateListenerOptions;
 import io.capawesome.capacitorjs.plugins.firebase.remoteconfig.classes.options.RemoveConfigUpdateListenerOptions;
 import io.capawesome.capacitorjs.plugins.firebase.remoteconfig.interfaces.NonEmptyResultCallback;
@@ -20,6 +25,7 @@ public class FirebaseRemoteConfigPlugin extends Plugin {
     public static final String TAG = "FirebaseRemoteConfig";
     public static final String ERROR_KEY_MISSING = "key must be provided.";
     public static final String ERROR_CALLBACK_ID_MISSING = "callbackId must be provided.";
+
 
     private Map<String, PluginCall> pluginCallMap = new HashMap<>();
 
@@ -157,6 +163,28 @@ public class FirebaseRemoteConfigPlugin extends Plugin {
     @PluginMethod
     public void setMinimumFetchInterval(PluginCall call) {
         call.reject("Not available on Android.");
+    }
+
+    @PluginMethod
+    public void setFetchTimeout(PluginCall call) {
+        try {
+            int fetchTimeoutInSeconds = call.getInt("fetchTimeoutInSeconds", -1);
+            if (fetchTimeoutInSeconds == -1) {
+                call.reject("fetchTimeoutInSeconds must be provided.");
+            }
+            Task<Void> task = implementation.setFetchTimeout(fetchTimeoutInSeconds);
+            task.addOnCompleteListener(
+                new OnCompleteListener<Void>() {
+                    @Override
+                    public void onComplete(@NonNull Task<Void> task) {
+                        call.resolve();
+                    }
+                }
+            );
+        } catch (Exception exception) {
+            Logger.error(TAG, exception.getMessage(), exception);
+            call.reject(exception.getMessage());
+        }
     }
 
     @PluginMethod(returnType = PluginMethod.RETURN_CALLBACK)

--- a/packages/remote-config/ios/Plugin/FirebaseRemoteConfig.swift
+++ b/packages/remote-config/ios/Plugin/FirebaseRemoteConfig.swift
@@ -56,6 +56,10 @@ import Capacitor
         return RemoteConfig.remoteConfig().configValue(forKey: key)
     }
 
+    @objc public func setFetchTimeout(fetchTimeoutInSeconds: Double) {
+        RemoteConfig.remoteConfig().configSettings.fetchTimeout = fetchTimeoutInSeconds
+    }
+
     @objc public func addConfigUpdateListener(_ options: AddConfigUpdateListenerOptions, completion: @escaping (Result?, Error?) -> Void) {
         let callbackId = options.getCallbackId()
 

--- a/packages/remote-config/ios/Plugin/FirebaseRemoteConfig.swift
+++ b/packages/remote-config/ios/Plugin/FirebaseRemoteConfig.swift
@@ -56,8 +56,9 @@ import Capacitor
         return RemoteConfig.remoteConfig().configValue(forKey: key)
     }
 
-    @objc public func setFetchTimeout(fetchTimeoutInSeconds: Double) {
+    @objc public func setConfigSettings(fetchTimeoutInSeconds: Double, minimumFetchIntervalInSeconds: Double) {
         RemoteConfig.remoteConfig().configSettings.fetchTimeout = fetchTimeoutInSeconds
+        RemoteConfig.remoteConfig().configSettings.minimumFetchInterval = minimumFetchIntervalInSeconds
     }
 
     @objc public func addConfigUpdateListener(_ options: AddConfigUpdateListenerOptions, completion: @escaping (Result?, Error?) -> Void) {

--- a/packages/remote-config/ios/Plugin/FirebaseRemoteConfig.swift
+++ b/packages/remote-config/ios/Plugin/FirebaseRemoteConfig.swift
@@ -40,6 +40,17 @@ import Capacitor
             }
         })
     }
+    
+    @objc public func fetchConfig(completion: @escaping (String?) -> Void) {
+        RemoteConfig.remoteConfig().fetch(completionHandler: { _, error in
+            if let error = error {
+                CAPLog.print("[", self.plugin.tag, "] ", error)
+                completion(error.localizedDescription)
+                return
+            }
+            completion(nil)
+        })
+    }
 
     @objc public func fetchConfig(minimumFetchIntervalInSeconds: Double, completion: @escaping (String?) -> Void) {
         RemoteConfig.remoteConfig().fetch(withExpirationDuration: minimumFetchIntervalInSeconds, completionHandler: { _, error in

--- a/packages/remote-config/ios/Plugin/FirebaseRemoteConfig.swift
+++ b/packages/remote-config/ios/Plugin/FirebaseRemoteConfig.swift
@@ -66,10 +66,6 @@ import Capacitor
     @objc public func getValue(_ key: String) -> RemoteConfigValue {
         return RemoteConfig.remoteConfig().configValue(forKey: key)
     }
-    
-    @objc public func getMinimumFetchIntervalInSeconds() -> Double {
-        return RemoteConfig.remoteConfig().configSettings.minimumFetchInterval
-    }
 
     @objc public func setSettings(fetchTimeoutInSeconds: Double, minimumFetchIntervalInSeconds: Double) {
         let settings = RemoteConfigSettings()

--- a/packages/remote-config/ios/Plugin/FirebaseRemoteConfig.swift
+++ b/packages/remote-config/ios/Plugin/FirebaseRemoteConfig.swift
@@ -40,17 +40,6 @@ import Capacitor
             }
         })
     }
-    
-    @objc public func fetchConfig(completion: @escaping (String?) -> Void) {
-        RemoteConfig.remoteConfig().fetch(completionHandler: { _, error in
-            if let error = error {
-                CAPLog.print("[", self.plugin.tag, "] ", error)
-                completion(error.localizedDescription)
-                return
-            }
-            completion(nil)
-        })
-    }
 
     @objc public func fetchConfig(minimumFetchIntervalInSeconds: Double, completion: @escaping (String?) -> Void) {
         RemoteConfig.remoteConfig().fetch(withExpirationDuration: minimumFetchIntervalInSeconds, completionHandler: { _, error in

--- a/packages/remote-config/ios/Plugin/FirebaseRemoteConfig.swift
+++ b/packages/remote-config/ios/Plugin/FirebaseRemoteConfig.swift
@@ -60,7 +60,7 @@ import Capacitor
         return RemoteConfig.remoteConfig().configSettings.minimumFetchInterval
     }
 
-    @objc public func setConfigSettings(fetchTimeoutInSeconds: Double, minimumFetchIntervalInSeconds: Double) {
+    @objc public func setSettings(fetchTimeoutInSeconds: Double, minimumFetchIntervalInSeconds: Double) {
         let settings = RemoteConfigSettings()
         settings.fetchTimeout = fetchTimeoutInSeconds
         settings.minimumFetchInterval = minimumFetchIntervalInSeconds

--- a/packages/remote-config/ios/Plugin/FirebaseRemoteConfig.swift
+++ b/packages/remote-config/ios/Plugin/FirebaseRemoteConfig.swift
@@ -55,6 +55,10 @@ import Capacitor
     @objc public func getValue(_ key: String) -> RemoteConfigValue {
         return RemoteConfig.remoteConfig().configValue(forKey: key)
     }
+    
+    @objc public func getMinimumFetchIntervalInSeconds() -> Double {
+        return RemoteConfig.remoteConfig().configSettings.minimumFetchInterval
+    }
 
     @objc public func setConfigSettings(fetchTimeoutInSeconds: Double, minimumFetchIntervalInSeconds: Double) {
         RemoteConfig.remoteConfig().configSettings.fetchTimeout = fetchTimeoutInSeconds

--- a/packages/remote-config/ios/Plugin/FirebaseRemoteConfig.swift
+++ b/packages/remote-config/ios/Plugin/FirebaseRemoteConfig.swift
@@ -61,8 +61,10 @@ import Capacitor
     }
 
     @objc public func setConfigSettings(fetchTimeoutInSeconds: Double, minimumFetchIntervalInSeconds: Double) {
-        RemoteConfig.remoteConfig().configSettings.fetchTimeout = fetchTimeoutInSeconds
-        RemoteConfig.remoteConfig().configSettings.minimumFetchInterval = minimumFetchIntervalInSeconds
+        let settings = RemoteConfigSettings()
+        settings.fetchTimeout = fetchTimeoutInSeconds
+        settings.minimumFetchInterval = minimumFetchIntervalInSeconds
+        RemoteConfig.remoteConfig().configSettings = settings
     }
 
     @objc public func addConfigUpdateListener(_ options: AddConfigUpdateListenerOptions, completion: @escaping (Result?, Error?) -> Void) {

--- a/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.m
+++ b/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.m
@@ -11,7 +11,7 @@ CAP_PLUGIN(FirebaseRemoteConfigPlugin, "FirebaseRemoteConfig",
            CAP_PLUGIN_METHOD(getNumber, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getString, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setMinimumFetchInterval, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHOD(setConfigSettings, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(setSettings, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(addConfigUpdateListener, CAPPluginReturnCallback);
            CAP_PLUGIN_METHOD(removeConfigUpdateListener, CAPPluginReturnPromise);
 )

--- a/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.m
+++ b/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.m
@@ -11,6 +11,7 @@ CAP_PLUGIN(FirebaseRemoteConfigPlugin, "FirebaseRemoteConfig",
            CAP_PLUGIN_METHOD(getNumber, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getString, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setMinimumFetchInterval, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(setFetchTimeout, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(addConfigUpdateListener, CAPPluginReturnCallback);
            CAP_PLUGIN_METHOD(removeConfigUpdateListener, CAPPluginReturnPromise);
 )

--- a/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.m
+++ b/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.m
@@ -11,7 +11,7 @@ CAP_PLUGIN(FirebaseRemoteConfigPlugin, "FirebaseRemoteConfig",
            CAP_PLUGIN_METHOD(getNumber, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getString, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setMinimumFetchInterval, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHOD(setFetchTimeout, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(setConfigSettings, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(addConfigUpdateListener, CAPPluginReturnCallback);
            CAP_PLUGIN_METHOD(removeConfigUpdateListener, CAPPluginReturnPromise);
 )

--- a/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.swift
+++ b/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.swift
@@ -42,18 +42,13 @@ public class FirebaseRemoteConfigPlugin: CAPPlugin {
     }
 
     @objc func fetchConfig(_ call: CAPPluginCall) {
-        let completionHandler: (String?) -> Void = { errorMessage in
+        let minimumFetchIntervalInSeconds = call.getDouble("minimumFetchIntervalInSeconds") ?? defaultMinimumFetchIntervalInSeconds
+        implementation?.fetchConfig(minimumFetchIntervalInSeconds: minimumFetchIntervalInSeconds, completion: { errorMessage in
             if let errorMessage = errorMessage {
                 call.reject(errorMessage)
                 return
             }
             call.resolve()
-        }
-        
-        if let minimumFetchIntervalInSeconds = call.getDouble("minimumFetchIntervalInSeconds") {
-            implementation?.fetchConfig(minimumFetchIntervalInSeconds: minimumFetchIntervalInSeconds, completion: completionHandler)
-        } else {
-            implementation?.fetchConfig(completion: completionHandler)
         }
     }
 

--- a/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.swift
+++ b/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.swift
@@ -12,6 +12,8 @@ public class FirebaseRemoteConfigPlugin: CAPPlugin {
     public let errorFetchAndActivatefailed = "fetchAndActivate failed."
     public let errorCallbackIdMissing = "callbackId must be provided."
 
+    private let defaultMinimumFetchIntervalInSeconds: Double = 43200
+    private let defaultFetchTimeoutInSeconds: Double = 60
     private var implementation: FirebaseRemoteConfig?
     private var pluginCallMap: [String: CAPPluginCall] = [:]
 
@@ -40,7 +42,7 @@ public class FirebaseRemoteConfigPlugin: CAPPlugin {
     }
 
     @objc func fetchConfig(_ call: CAPPluginCall) {
-        let minimumFetchIntervalInSeconds = call.getDouble("minimumFetchIntervalInSeconds") ?? 43200
+        let minimumFetchIntervalInSeconds = call.getDouble("minimumFetchIntervalInSeconds") ?? defaultMinimumFetchIntervalInSeconds
         implementation?.fetchConfig(minimumFetchIntervalInSeconds: minimumFetchIntervalInSeconds, completion: { errorMessage in
             if let errorMessage = errorMessage {
                 call.reject(errorMessage)
@@ -90,12 +92,10 @@ public class FirebaseRemoteConfigPlugin: CAPPlugin {
         call.reject("Not available on iOS.")
     }
 
-    @objc func setFetchTimeout(_ call: CAPPluginCall) {
-        guard let fetchTimeoutInSeconds = call.getDouble("fetchTimeoutInSeconds") else {
-            call.reject("fetchTimeoutInSeconds must be provided.")
-            return
-        }
-        implementation?.setFetchTimeout(fetchTimeoutInSeconds: fetchTimeoutInSeconds)
+    @objc func setConfigSettings(_ call: CAPPluginCall) {
+        let fetchTimeoutInSeconds = call.getDouble("fetchTimeoutInSeconds") ?? defaultFetchTimeoutInSeconds
+        let minimumFetchIntervalInSeconds = call.getDouble("minimumFetchIntervalInSeconds") ?? defaultMinimumFetchIntervalInSeconds
+        implementation?.setConfigSettings(fetchTimeoutInSeconds: fetchTimeoutInSeconds, minimumFetchIntervalInSeconds: minimumFetchIntervalInSeconds)
         call.resolve()
     }
 

--- a/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.swift
+++ b/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.swift
@@ -49,7 +49,7 @@ public class FirebaseRemoteConfigPlugin: CAPPlugin {
                 return
             }
             call.resolve()
-        }
+        })
     }
 
     @objc func getBoolean(_ call: CAPPluginCall) {

--- a/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.swift
+++ b/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.swift
@@ -94,7 +94,7 @@ public class FirebaseRemoteConfigPlugin: CAPPlugin {
     }
 
     @objc func setMinimumFetchInterval(_ call: CAPPluginCall) {
-        call.reject("Not available on iOS. Use setConfigSettings.")
+        call.reject("Not available on iOS.")
     }
 
     @objc func setSettings(_ call: CAPPluginCall) {

--- a/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.swift
+++ b/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.swift
@@ -42,19 +42,19 @@ public class FirebaseRemoteConfigPlugin: CAPPlugin {
     }
 
     @objc func fetchConfig(_ call: CAPPluginCall) {
-        let minimumFetchIntervalInSeconds: Double = {
-            let defaultValue = defaultMinimumFetchIntervalInSeconds
-            let settingsValue = implementation?.getMinimumFetchIntervalInSeconds()
-            return call.getDouble("minimumFetchIntervalInSeconds") ?? settingsValue ?? defaultValue
-        }()
-
-        implementation?.fetchConfig(minimumFetchIntervalInSeconds: minimumFetchIntervalInSeconds, completion: { errorMessage in
+        let completionHandler: (String?) -> Void = { errorMessage in
             if let errorMessage = errorMessage {
                 call.reject(errorMessage)
                 return
             }
             call.resolve()
-        })
+        }
+        
+        if let minimumFetchIntervalInSeconds = call.getDouble("minimumFetchIntervalInSeconds") {
+            implementation?.fetchConfig(minimumFetchIntervalInSeconds: minimumFetchIntervalInSeconds, completion: completionHandler)
+        } else {
+            implementation?.fetchConfig(completion: completionHandler)
+        }
     }
 
     @objc func getBoolean(_ call: CAPPluginCall) {

--- a/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.swift
+++ b/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.swift
@@ -90,6 +90,15 @@ public class FirebaseRemoteConfigPlugin: CAPPlugin {
         call.reject("Not available on iOS.")
     }
 
+    @objc func setFetchTimeout(_ call: CAPPluginCall) {
+        guard let fetchTimeoutInSeconds = call.getDouble("fetchTimeoutInSeconds") else {
+            call.reject("fetchTimeoutInSeconds must be provided.")
+            return
+        }
+        implementation?.setFetchTimeout(fetchTimeoutInSeconds: fetchTimeoutInSeconds)
+        call.resolve()
+    }
+
     @objc func addConfigUpdateListener(_ call: CAPPluginCall) {
         call.keepAlive = true
 

--- a/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.swift
+++ b/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.swift
@@ -97,10 +97,10 @@ public class FirebaseRemoteConfigPlugin: CAPPlugin {
         call.reject("Not available on iOS. Use setConfigSettings.")
     }
 
-    @objc func setConfigSettings(_ call: CAPPluginCall) {
+    @objc func setSettings(_ call: CAPPluginCall) {
         let fetchTimeoutInSeconds = call.getDouble("fetchTimeoutInSeconds") ?? defaultFetchTimeoutInSeconds
         let minimumFetchIntervalInSeconds = call.getDouble("minimumFetchIntervalInSeconds") ?? defaultMinimumFetchIntervalInSeconds
-        implementation?.setConfigSettings(fetchTimeoutInSeconds: fetchTimeoutInSeconds, minimumFetchIntervalInSeconds: minimumFetchIntervalInSeconds)
+        implementation?.setSettings(fetchTimeoutInSeconds: fetchTimeoutInSeconds, minimumFetchIntervalInSeconds: minimumFetchIntervalInSeconds)
         call.resolve()
     }
 

--- a/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.swift
+++ b/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.swift
@@ -42,7 +42,12 @@ public class FirebaseRemoteConfigPlugin: CAPPlugin {
     }
 
     @objc func fetchConfig(_ call: CAPPluginCall) {
-        let minimumFetchIntervalInSeconds = call.getDouble("minimumFetchIntervalInSeconds") ?? defaultMinimumFetchIntervalInSeconds
+        let minimumFetchIntervalInSeconds: Double = {
+            let defaultValue = defaultMinimumFetchIntervalInSeconds
+            let settingsValue = implementation?.getMinimumFetchIntervalInSeconds()
+            return call.getDouble("minimumFetchIntervalInSeconds") ?? settingsValue ?? defaultValue
+        }()
+
         implementation?.fetchConfig(minimumFetchIntervalInSeconds: minimumFetchIntervalInSeconds, completion: { errorMessage in
             if let errorMessage = errorMessage {
                 call.reject(errorMessage)

--- a/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.swift
+++ b/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.swift
@@ -94,7 +94,7 @@ public class FirebaseRemoteConfigPlugin: CAPPlugin {
     }
 
     @objc func setMinimumFetchInterval(_ call: CAPPluginCall) {
-        call.reject("Not available on iOS.")
+        call.reject("Not available on iOS. Use setConfigSettings.")
     }
 
     @objc func setConfigSettings(_ call: CAPPluginCall) {

--- a/packages/remote-config/src/definitions.ts
+++ b/packages/remote-config/src/definitions.ts
@@ -41,7 +41,7 @@ export interface FirebaseRemoteConfigPlugin {
    * Only available for Web.
    *
    * @since 1.3.0
-   * @deprecated Use `setSettings` instead.
+   * @deprecated Use `setSettings(...)` instead.
    */
   setMinimumFetchInterval(
     options: SetMinimumFetchIntervalOptions,

--- a/packages/remote-config/src/definitions.ts
+++ b/packages/remote-config/src/definitions.ts
@@ -50,7 +50,7 @@ export interface FirebaseRemoteConfigPlugin {
    *
    * @since 6.2.0
    */
-  setSettings(options: SetConfigSettingsOptions): Promise<void>;
+  setSettings(options: SetSettingsOptions): Promise<void>;
   /**
    * Add a listener for the config update event.
    *

--- a/packages/remote-config/src/definitions.ts
+++ b/packages/remote-config/src/definitions.ts
@@ -201,7 +201,7 @@ export interface SetMinimumFetchIntervalOptions {
 /**
  * @since 6.2.0
  */
-export interface SetConfigSettingsOptions {
+export interface SetSettingsOptions {
   /**
    * Defines the maximum amount of milliseconds to wait for a response when fetching configuration from the Remote Config server.
    *

--- a/packages/remote-config/src/definitions.ts
+++ b/packages/remote-config/src/definitions.ts
@@ -47,6 +47,9 @@ export interface FirebaseRemoteConfigPlugin {
   ): Promise<void>;
   /**
    * Set the remote config settings.
+   * 
+   * On Android, the settings values are saved in SharedPreferences.
+   * Therefore, please note that even if setSettings is removed, the saved values will still be used.
    *
    * @since 6.2.0
    */

--- a/packages/remote-config/src/definitions.ts
+++ b/packages/remote-config/src/definitions.ts
@@ -41,6 +41,7 @@ export interface FirebaseRemoteConfigPlugin {
    * Only available for Web.
    *
    * @since 1.3.0
+   * @deprecated Use `setSettings` instead.
    */
   setMinimumFetchInterval(
     options: SetMinimumFetchIntervalOptions,

--- a/packages/remote-config/src/definitions.ts
+++ b/packages/remote-config/src/definitions.ts
@@ -50,7 +50,7 @@ export interface FirebaseRemoteConfigPlugin {
    *
    * @since 6.2.0
    */
-  setConfigSettings(options: SetConfigSettingsOptions): Promise<void>;
+  setSettings(options: SetConfigSettingsOptions): Promise<void>;
   /**
    * Add a listener for the config update event.
    *

--- a/packages/remote-config/src/definitions.ts
+++ b/packages/remote-config/src/definitions.ts
@@ -46,6 +46,12 @@ export interface FirebaseRemoteConfigPlugin {
     options: SetMinimumFetchIntervalOptions,
   ): Promise<void>;
   /**
+   * Set the remote config settings.
+   *
+   * @since 6.2.0
+   */
+  setConfigSettings(options: SetConfigSettingsOptions): Promise<void>;
+  /**
    * Add a listener for the config update event.
    *
    * Only available for Android and iOS.
@@ -203,7 +209,7 @@ export interface SetConfigSettingsOptions {
    * @default 60
    * @see https://firebase.google.com/docs/reference/js/remote-config.remoteconfigsettings#remoteconfigsettingsfetchtimeoutmillis
    */
-  fetchTimeoutInSeconds: number;
+  fetchTimeoutInSeconds?: number;
 
   /**
    * Define the maximum age in seconds of an entry in the config cache before it is considered stale.
@@ -213,7 +219,7 @@ export interface SetConfigSettingsOptions {
    * @default 43200
    * @see https://firebase.google.com/docs/reference/js/remote-config.remoteconfigsettings#remoteconfigsettingsminimumfetchintervalmillis
    */
-  minimumFetchIntervalInSeconds: number;
+  minimumFetchIntervalInSeconds?: number;
 }
 
 /**

--- a/packages/remote-config/src/definitions.ts
+++ b/packages/remote-config/src/definitions.ts
@@ -210,7 +210,6 @@ export interface SetSettingsOptions {
    * @see https://firebase.google.com/docs/reference/js/remote-config.remoteconfigsettings#remoteconfigsettingsfetchtimeoutmillis
    */
   fetchTimeoutInSeconds?: number;
-
   /**
    * Define the maximum age in seconds of an entry in the config cache before it is considered stale.
    * During development, it's recommended to set a relatively low minimum fetch interval.

--- a/packages/remote-config/src/definitions.ts
+++ b/packages/remote-config/src/definitions.ts
@@ -192,15 +192,28 @@ export interface SetMinimumFetchIntervalOptions {
   minimumFetchIntervalInSeconds: number;
 }
 
-export interface SetFetchTimeoutOptions {
+/**
+ * @since 6.2.0
+ */
+export interface SetConfigSettingsOptions {
   /**
    * Defines the maximum amount of milliseconds to wait for a response when fetching configuration from the Remote Config server.
-   * In Firebase SDK, Defaults to 60 seconds.
    *
    * @since 6.2.0
+   * @default 60
    * @see https://firebase.google.com/docs/reference/js/remote-config.remoteconfigsettings#remoteconfigsettingsfetchtimeoutmillis
    */
   fetchTimeoutInSeconds: number;
+
+  /**
+   * Define the maximum age in seconds of an entry in the config cache before it is considered stale.
+   * During development, it's recommended to set a relatively low minimum fetch interval.
+   *
+   * @since 6.2.0
+   * @default 43200
+   * @see https://firebase.google.com/docs/reference/js/remote-config.remoteconfigsettings#remoteconfigsettingsminimumfetchintervalmillis
+   */
+  minimumFetchIntervalInSeconds: number;
 }
 
 /**

--- a/packages/remote-config/src/definitions.ts
+++ b/packages/remote-config/src/definitions.ts
@@ -192,6 +192,17 @@ export interface SetMinimumFetchIntervalOptions {
   minimumFetchIntervalInSeconds: number;
 }
 
+export interface SetFetchTimeoutOptions {
+  /**
+   * Defines the maximum amount of milliseconds to wait for a response when fetching configuration from the Remote Config server.
+   * In Firebase SDK, Defaults to 60 seconds.
+   *
+   * @since 6.2.0
+   * @see https://firebase.google.com/docs/reference/js/remote-config.remoteconfigsettings#remoteconfigsettingsfetchtimeoutmillis
+   */
+  fetchTimeoutInSeconds: number;
+}
+
 /**
  * @since 5.4.0
  */

--- a/packages/remote-config/src/definitions.ts
+++ b/packages/remote-config/src/definitions.ts
@@ -48,7 +48,7 @@ export interface FirebaseRemoteConfigPlugin {
   ): Promise<void>;
   /**
    * Set the remote config settings.
-   * 
+   *
    * On Android, the settings values are persisted in SharedPreferences.
    *
    * @since 6.2.0

--- a/packages/remote-config/src/definitions.ts
+++ b/packages/remote-config/src/definitions.ts
@@ -48,8 +48,7 @@ export interface FirebaseRemoteConfigPlugin {
   /**
    * Set the remote config settings.
    * 
-   * On Android, the settings values are saved in SharedPreferences.
-   * Therefore, please note that even if setSettings is removed, the saved values will still be used.
+   * On Android, the settings values are persisted in SharedPreferences.
    *
    * @since 6.2.0
    */

--- a/packages/remote-config/src/web.ts
+++ b/packages/remote-config/src/web.ts
@@ -70,10 +70,14 @@ export class FirebaseRemoteConfigWeb
     options: SetConfigSettingsOptions,
   ): Promise<void> {
     const remoteConfig = getRemoteConfig();
-    remoteConfig.settings.fetchTimeoutMillis =
-      options.fetchTimeoutInSeconds * 1000;
-    remoteConfig.settings.minimumFetchIntervalMillis =
-      options.minimumFetchIntervalInSeconds * 1000;
+    if (options.fetchTimeoutInSeconds) {
+      remoteConfig.settings.fetchTimeoutMillis =
+        options.fetchTimeoutInSeconds * 1000;
+    }
+    if (options.minimumFetchIntervalInSeconds) {
+      remoteConfig.settings.minimumFetchIntervalMillis =
+        options.minimumFetchIntervalInSeconds * 1000;
+    }
   }
 
   public async addConfigUpdateListener(

--- a/packages/remote-config/src/web.ts
+++ b/packages/remote-config/src/web.ts
@@ -70,11 +70,11 @@ export class FirebaseRemoteConfigWeb
     options: SetConfigSettingsOptions,
   ): Promise<void> {
     const remoteConfig = getRemoteConfig();
-    if (options.fetchTimeoutInSeconds) {
+    if (typeof options.fetchTimeoutInSeconds === 'number') {
       remoteConfig.settings.fetchTimeoutMillis =
         options.fetchTimeoutInSeconds * 1000;
     }
-    if (options.minimumFetchIntervalInSeconds) {
+    if (typeof options.minimumFetchIntervalInSeconds === 'number') {
       remoteConfig.settings.minimumFetchIntervalMillis =
         options.minimumFetchIntervalInSeconds * 1000;
     }

--- a/packages/remote-config/src/web.ts
+++ b/packages/remote-config/src/web.ts
@@ -18,6 +18,7 @@ import type {
   GetStringResult,
   RemoveConfigUpdateListenerOptions,
   SetMinimumFetchIntervalOptions,
+  SetFetchTimeoutOptions,
 } from './definitions';
 
 export class FirebaseRemoteConfigWeb
@@ -63,6 +64,14 @@ export class FirebaseRemoteConfigWeb
     const remoteConfig = getRemoteConfig();
     remoteConfig.settings.minimumFetchIntervalMillis =
       options.minimumFetchIntervalInSeconds * 1000;
+  }
+
+  public async setFetchTimeout(
+    options: SetFetchTimeoutOptions,
+  ): Promise<void> {
+    const remoteConfig = getRemoteConfig();
+    remoteConfig.settings.fetchTimeoutMillis =
+      options.fetchTimeoutInSeconds * 1000;
   }
 
   public async addConfigUpdateListener(

--- a/packages/remote-config/src/web.ts
+++ b/packages/remote-config/src/web.ts
@@ -74,7 +74,7 @@ export class FirebaseRemoteConfigWeb
       remoteConfig.settings.fetchTimeoutMillis =
         options.fetchTimeoutInSeconds * 1000;
     }
-    if (typeof options.minimumFetchIntervalInSeconds === 'number') {
+    if (options.minimumFetchIntervalInSeconds !== undefined) {
       remoteConfig.settings.minimumFetchIntervalMillis =
         options.minimumFetchIntervalInSeconds * 1000;
     }

--- a/packages/remote-config/src/web.ts
+++ b/packages/remote-config/src/web.ts
@@ -70,7 +70,7 @@ export class FirebaseRemoteConfigWeb
     options: SetConfigSettingsOptions,
   ): Promise<void> {
     const remoteConfig = getRemoteConfig();
-    if (typeof options.fetchTimeoutInSeconds === 'number') {
+    if (options.fetchTimeoutInSeconds !== undefined) {
       remoteConfig.settings.fetchTimeoutMillis =
         options.fetchTimeoutInSeconds * 1000;
     }

--- a/packages/remote-config/src/web.ts
+++ b/packages/remote-config/src/web.ts
@@ -18,7 +18,7 @@ import type {
   GetStringResult,
   RemoveConfigUpdateListenerOptions,
   SetMinimumFetchIntervalOptions,
-  SetFetchTimeoutOptions,
+  SetConfigSettingsOptions,
 } from './definitions';
 
 export class FirebaseRemoteConfigWeb
@@ -66,12 +66,14 @@ export class FirebaseRemoteConfigWeb
       options.minimumFetchIntervalInSeconds * 1000;
   }
 
-  public async setFetchTimeout(
-    options: SetFetchTimeoutOptions,
+  public async setConfigSettings(
+    options: SetConfigSettingsOptions,
   ): Promise<void> {
     const remoteConfig = getRemoteConfig();
     remoteConfig.settings.fetchTimeoutMillis =
       options.fetchTimeoutInSeconds * 1000;
+    remoteConfig.settings.minimumFetchIntervalMillis =
+      options.minimumFetchIntervalInSeconds * 1000;
   }
 
   public async addConfigUpdateListener(

--- a/packages/remote-config/src/web.ts
+++ b/packages/remote-config/src/web.ts
@@ -18,7 +18,7 @@ import type {
   GetStringResult,
   RemoveConfigUpdateListenerOptions,
   SetMinimumFetchIntervalOptions,
-  SetConfigSettingsOptions,
+  SetSettingsOptions,
 } from './definitions';
 
 export class FirebaseRemoteConfigWeb
@@ -66,9 +66,7 @@ export class FirebaseRemoteConfigWeb
       options.minimumFetchIntervalInSeconds * 1000;
   }
 
-  public async setConfigSettings(
-    options: SetConfigSettingsOptions,
-  ): Promise<void> {
+  public async setSettings(options: SetSettingsOptions): Promise<void> {
     const remoteConfig = getRemoteConfig();
     if (options.fetchTimeoutInSeconds !== undefined) {
       remoteConfig.settings.fetchTimeoutMillis =


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

Close https://github.com/capawesome-team/capacitor-firebase/issues/687 
Close https://github.com/capawesome-team/capacitor-firebase/issues/688

--- 

Example: 

```typescript
await FirebaseRemoteConfig.setConfigSettings({
  fetchTimeoutInSeconds: 10,
  minimumFetchIntervalInSeconds: 0,
})
```

At first, I was thinking of adding a method that could only set fetchTimeoutInSeconds. But when I checked the Firebase SDK interface for Android, I found that it could not be set individually, so I added a method to set it all together
