### PR TITLE
Add the idTokenChange handler; address iOS auth changes

### DIFF
--- a/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthentication.java
+++ b/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthentication.java
@@ -54,6 +54,7 @@ public class FirebaseAuthentication {
     private FirebaseAuthenticationPlugin plugin;
     private FirebaseAuthenticationConfig config;
     private FirebaseAuth.AuthStateListener firebaseAuthStateListener;
+    private FirebaseAuth.IdTokenListener firebaseIdTokenListener;
     private AppleAuthProviderHandler appleAuthProviderHandler;
     private FacebookAuthProviderHandler facebookAuthProviderHandler;
     private GoogleAuthProviderHandler googleAuthProviderHandler;
@@ -70,6 +71,11 @@ public class FirebaseAuthentication {
                 this.plugin.handleAuthStateChange();
             };
         getFirebaseAuthInstance().addAuthStateListener(this.firebaseAuthStateListener);
+        this.firebaseIdTokenListener =
+            firebaseAuth -> {
+                this.plugin.handleIdTokenChange();
+            };
+        getFirebaseAuthInstance().addIdTokenListener(this.firebaseIdTokenListener);
     }
 
     public void applyActionCode(@NonNull String oobCode, @NonNull Runnable callback) {

--- a/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthenticationPlugin.java
+++ b/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthenticationPlugin.java
@@ -62,6 +62,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
     public static final String ERROR_SIGN_IN_ANONYMOUSLY_SKIP_NATIVE_AUTH =
         "signInAnonymously cannot be used in combination with skipNativeAuth.";
     public static final String AUTH_STATE_CHANGE_EVENT = "authStateChange";
+    public static final String ID_TOKEN_CHANGE_EVENT = "idTokenChange";
     private FirebaseAuthenticationConfig config;
     private FirebaseAuthentication implementation;
 
@@ -938,6 +939,14 @@ public class FirebaseAuthenticationPlugin extends Plugin {
         JSObject result = new JSObject();
         result.put("user", (userResult == null ? JSONObject.NULL : userResult));
         notifyListeners(AUTH_STATE_CHANGE_EVENT, result, true);
+    }
+
+    public void handleIdTokenChange() {
+        FirebaseUser user = implementation.getCurrentUser();
+        JSObject userResult = FirebaseAuthenticationHelper.createUserResult(user);
+        JSObject result = new JSObject();
+        result.put("user", (userResult == null ? JSONObject.NULL : userResult));
+        notifyListeners(ID_TOKEN_CHANGE_EVENT, result, true);
     }
 
     @Override

--- a/packages/authentication/ios/Plugin/FirebaseAuthentication.swift
+++ b/packages/authentication/ios/Plugin/FirebaseAuthentication.swift
@@ -25,8 +25,11 @@ public typealias AuthStateChangedObserver = () -> Void
             FirebaseApp.configure()
         }
         self.initAuthProviderHandlers(config: config)
-        Auth.auth().addStateDidChangeListener {_, _ in
-            self.plugin.handleAuthStateChange()
+        Auth.auth().addStateDidChangeListener {auth, user in
+            self.plugin.handleAuthStateChange(user)
+        }
+        Auth.auth().addIDTokenDidChangeListener {auth, user in
+            self.plugin.handleIdTokenChange(user)
         }
     }
 

--- a/packages/authentication/ios/Plugin/FirebaseAuthenticationPlugin.swift
+++ b/packages/authentication/ios/Plugin/FirebaseAuthenticationPlugin.swift
@@ -36,6 +36,7 @@ public class FirebaseAuthenticationPlugin: CAPPlugin {
         "signInAnonymously cannot be used in combination with skipNativeAuth."
     public let errorDeviceUnsupported = "Device is not supported. At least iOS 13 is required."
     public let authStateChangeEvent = "authStateChange"
+    public let idTokenChangeEvent = "idTokenChange"
     public let phoneVerificationFailedEvent = "phoneVerificationFailed"
     public let phoneCodeSentEvent = "phoneCodeSent"
     private var implementation: FirebaseAuthentication?
@@ -560,12 +561,18 @@ public class FirebaseAuthenticationPlugin: CAPPlugin {
         call.resolve()
     }
 
-    @objc func handleAuthStateChange() {
-        let user = implementation?.getCurrentUser()
+    @objc func handleAuthStateChange(_ user: User?) {
         let userResult = FirebaseAuthenticationHelper.createUserResult(user)
         var result = JSObject()
         result["user"] = userResult ?? NSNull()
         notifyListeners(authStateChangeEvent, data: result, retainUntilConsumed: true)
+    }
+
+    @objc func handleIdTokenChange(_ user: User?) {
+        let userResult = FirebaseAuthenticationHelper.createUserResult(user)
+        var result = JSObject()
+        result["user"] = userResult ?? NSNull()
+        notifyListeners(idTokenChangeEvent, data: result, retainUntilConsumed: true)
     }
 
     @objc func handlePhoneVerificationFailed(_ error: Error) {

--- a/packages/authentication/src/web.ts
+++ b/packages/authentication/src/web.ts
@@ -110,6 +110,7 @@ export class FirebaseAuthenticationWeb
   implements FirebaseAuthenticationPlugin
 {
   public static readonly AUTH_STATE_CHANGE_EVENT = 'authStateChange';
+  public static readonly ID_TOKEN_CHANGE_EVENT = 'idTokenChange';
   public static readonly PHONE_CODE_SENT_EVENT = 'phoneCodeSent';
   public static readonly PHONE_VERIFICATION_FAILED_EVENT =
     'phoneVerificationFailed';
@@ -127,6 +128,7 @@ export class FirebaseAuthenticationWeb
     super();
     const auth = getAuth();
     auth.onAuthStateChanged(user => this.handleAuthStateChange(user));
+    auth.onIdTokenChanged(user => this.handleIdTokenChanged(user));
   }
 
   public async applyActionCode(options: ApplyActionCodeOptions): Promise<void> {
@@ -768,6 +770,18 @@ export class FirebaseAuthenticationWeb
     };
     this.notifyListeners(
       FirebaseAuthenticationWeb.AUTH_STATE_CHANGE_EVENT,
+      change,
+      true,
+    );
+  }
+
+  private handleIdTokenChanged(user: FirebaseUser | null): void {
+    const userResult = this.createUserResult(user);
+    const change: AuthStateChange = {
+      user: userResult,
+    };
+    this.notifyListeners(
+      FirebaseAuthenticationWeb.ID_TOKEN_CHANGE_EVENT,
       change,
       true,
     );


### PR DESCRIPTION
## Changes

This PR addresses two issues:
- The idTokenChange event not being available for consumption
- The iOS auth state change not correctly relying on the user passed from the handler

See the iOS docs [here](https://firebase.google.com/docs/auth/ios/manage-users#get_the_currently_signed-in_user) where they recommend how to use the listeners.

## Testing

I do not know how to test this effectively. It builds, but that's half the battle. This is my first capacitor plugin change, so come guidance on effective testing practices would be helpful! I'll test before I finalize. I'll open an issue as well (after I test).

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The changes have been tested successfully.
- [ ] A changeset has been created (`npm run changeset`).
- [ ] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).
