### PR TITLE
fix(crashlytics): `crash(...)` method now respects message option

### DIFF
--- a/.changeset/thin-hornets-explain.md
+++ b/.changeset/thin-hornets-explain.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/crashlytics': major
+---
+
+.crash now checks for message param

--- a/.changeset/thin-hornets-explain.md
+++ b/.changeset/thin-hornets-explain.md
@@ -1,5 +1,5 @@
 ---
-'@capacitor-firebase/crashlytics': major
+'@capacitor-firebase/crashlytics': patch
 ---
 
-.crash now checks for message param
+fix(ios): `crash(...)` method now respects message option

--- a/packages/crashlytics/ios/Plugin/FirebaseCrashlytics.swift
+++ b/packages/crashlytics/ios/Plugin/FirebaseCrashlytics.swift
@@ -10,8 +10,8 @@ import FirebaseCrashlytics
         }
     }
 
-    @objc public func crash() {
-        fatalError()
+    @objc public func crash(_ message: String) {
+        fatalError(message)
     }
 
     @objc func setCustomKey(_ key: String, _ type: String, _ call: CAPPluginCall) {

--- a/packages/crashlytics/ios/Plugin/FirebaseCrashlyticsPlugin.swift
+++ b/packages/crashlytics/ios/Plugin/FirebaseCrashlyticsPlugin.swift
@@ -19,8 +19,12 @@ public class FirebaseCrashlyticsPlugin: CAPPlugin {
     }
 
     @objc func crash(_ call: CAPPluginCall) {
+        guard let message = call.getString("message") else {
+            call.reject(errorMessageMissing)
+            return
+        }
         call.resolve()
-        implementation?.crash()
+        implementation?.crash(message)
     }
 
     @objc func setCustomKey(_ call: CAPPluginCall) {


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

---

Close #720