### PR TITLE
fix(authentication): explicitly request Google auth token with provided scopes on Android

### DIFF
--- a/.changeset/selfish-steaks-enjoy.md
+++ b/.changeset/selfish-steaks-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/authentication': patch
+---
+
+fix(android): Google auth token explicitly requested with provided scopes

--- a/.changeset/selfish-steaks-enjoy.md
+++ b/.changeset/selfish-steaks-enjoy.md
@@ -2,4 +2,4 @@
 '@capacitor-firebase/authentication': patch
 ---
 
-fix(android): Google auth token explicitly requested with provided scopes
+fix(android): explicitly request Google auth token with provided scopes

--- a/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/handlers/GoogleAuthProviderHandler.java
+++ b/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/handlers/GoogleAuthProviderHandler.java
@@ -82,7 +82,11 @@ public class GoogleAuthProviderHandler {
 
                     try {
                         accessToken =
-                            GoogleAuthUtil.getToken(mGoogleSignInClient.getApplicationContext(), account.getAccount(), String.join(" ", scopes));
+                            GoogleAuthUtil.getToken(
+                                mGoogleSignInClient.getApplicationContext(),
+                                account.getAccount(),
+                                String.join(" ", scopes)
+                            );
                         // Clears local cache after every login attempt
                         // to ensure permissions changes elsewhere are reflected in future tokens
                         GoogleAuthUtil.clearToken(mGoogleSignInClient.getApplicationContext(), accessToken);

--- a/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/handlers/GoogleAuthProviderHandler.java
+++ b/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/handlers/GoogleAuthProviderHandler.java
@@ -22,6 +22,7 @@ import io.capawesome.capacitorjs.plugins.firebase.authentication.FirebaseAuthent
 import io.capawesome.capacitorjs.plugins.firebase.authentication.FirebaseAuthenticationPlugin;
 import io.capawesome.capacitorjs.plugins.firebase.authentication.R;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import org.json.JSONException;
 
@@ -63,9 +64,25 @@ public class GoogleAuthProviderHandler {
             new Thread(
                 () -> {
                     String accessToken = null;
+                    ArrayList<String> scopes = new ArrayList<>();
+                    scopes.add("oauth2:email");
+                    JSArray additionalScopes = call.getArray("scopes");
+                    if (additionalScopes != null) {
+                        List<String> additionalScopesList = null;
+                        try {
+                            additionalScopesList = additionalScopes.toList();
+                        } catch (JSONException exception) {
+                            Log.e(FirebaseAuthenticationPlugin.TAG, "handleOnActivityResult failed.", exception);
+                        }
+
+                        if (additionalScopesList != null) {
+                            scopes.addAll(additionalScopesList);
+                        }
+                    }
+
                     try {
                         accessToken =
-                            GoogleAuthUtil.getToken(mGoogleSignInClient.getApplicationContext(), account.getAccount(), "oauth2:email");
+                            GoogleAuthUtil.getToken(mGoogleSignInClient.getApplicationContext(), account.getAccount(), String.join(" ", scopes));
                         // Clears local cache after every login attempt
                         // to ensure permissions changes elsewhere are reflected in future tokens
                         GoogleAuthUtil.clearToken(mGoogleSignInClient.getApplicationContext(), accessToken);

--- a/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/handlers/GoogleAuthProviderHandler.java
+++ b/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/handlers/GoogleAuthProviderHandler.java
@@ -64,21 +64,9 @@ public class GoogleAuthProviderHandler {
             new Thread(
                 () -> {
                     String accessToken = null;
-                    ArrayList<String> scopes = new ArrayList<>();
+                    List<String> scopes = new ArrayList<>();
                     scopes.add("oauth2:email");
-                    JSArray additionalScopes = call.getArray("scopes");
-                    if (additionalScopes != null) {
-                        List<String> additionalScopesList = null;
-                        try {
-                            additionalScopesList = additionalScopes.toList();
-                        } catch (JSONException exception) {
-                            Log.e(FirebaseAuthenticationPlugin.TAG, "handleOnActivityResult failed.", exception);
-                        }
-
-                        if (additionalScopesList != null) {
-                            scopes.addAll(additionalScopesList);
-                        }
-                    }
+                    scopes.addAll(getScopesAsList(call));
 
                     try {
                         accessToken =
@@ -126,19 +114,26 @@ public class GoogleAuthProviderHandler {
             .requestEmail();
 
         if (call != null) {
-            JSArray scopes = call.getArray("scopes");
-            if (scopes != null) {
-                try {
-                    List<String> scopeList = scopes.toList();
-                    for (String scope : scopeList) {
-                        googleSignInOptionsBuilder = googleSignInOptionsBuilder.requestScopes(new Scope(scope));
-                    }
-                } catch (JSONException exception) {
-                    Log.e(FirebaseAuthenticationPlugin.TAG, "buildGoogleSignInClient failed.", exception);
-                }
+            List<String> scopeList = getScopesAsList(call);
+            for (String scope : scopeList) {
+                googleSignInOptionsBuilder = googleSignInOptionsBuilder.requestScopes(new Scope(scope));
             }
         }
 
         return GoogleSignIn.getClient(pluginImplementation.getPlugin().getActivity(), googleSignInOptionsBuilder.build());
+    }
+
+    private List<String> getScopesAsList(@NonNull PluginCall call) {
+        List<String> scopeList = new ArrayList<>();
+        JSArray scopes = call.getArray("scopes");
+        if (scopes != null) {
+            try {
+                scopeList = scopes.toList();
+            } catch (JSONException exception) {
+                Log.e(FirebaseAuthenticationPlugin.TAG, "getScopesAsList failed.", exception);
+            }
+        }
+
+        return scopeList;
     }
 }


### PR DESCRIPTION
This PR explicitly requests scopes when getting a Google access token post-Sign In with Google.

It looks like not requesting scopes explicitly works _most_ of the time, but not all of the time. I had two users with this bug [(nkalupahana/baseline#402)](https://github.com/nkalupahana/baseline/issues/401), and this change fixed it for them ([patch](https://github.com/nkalupahana/baseline/blob/main/patches/%40capacitor-firebase%2Bauthentication%2B6.0.0.patch)). This PR upstreams our patch.

Closes #725 

## Pull request checklist

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).
