### PR TITLE
fix(analytics): setUserId accepts null values

### DIFF
--- a/.changeset/smooth-mirrors-bow.md
+++ b/.changeset/smooth-mirrors-bow.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/analytics': minor
+---
+
+fix(analytics): setUserId accepts null values

--- a/.changeset/smooth-mirrors-bow.md
+++ b/.changeset/smooth-mirrors-bow.md
@@ -1,5 +1,5 @@
 ---
-'@capacitor-firebase/analytics': minor
+'@capacitor-firebase/analytics': patch
 ---
 
-fix(analytics): setUserId accepts null values
+fix(web): `setUserId(...)` has set an empty string instead of `null`

--- a/package-lock.json
+++ b/package-lock.json
@@ -7945,7 +7945,7 @@
     },
     "packages/analytics": {
       "name": "@capacitor-firebase/analytics",
-      "version": "6.2.0",
+      "version": "6.1.0",
       "funding": [
         {
           "type": "github",
@@ -7998,7 +7998,7 @@
     },
     "packages/app": {
       "name": "@capacitor-firebase/app",
-      "version": "6.2.0",
+      "version": "6.1.0",
       "funding": [
         {
           "type": "github",
@@ -8039,7 +8039,7 @@
     },
     "packages/app-check": {
       "name": "@capacitor-firebase/app-check",
-      "version": "6.2.0",
+      "version": "6.1.0",
       "funding": [
         {
           "type": "github",
@@ -8104,7 +8104,7 @@
     },
     "packages/authentication": {
       "name": "@capacitor-firebase/authentication",
-      "version": "6.2.0",
+      "version": "6.1.0",
       "funding": [
         {
           "type": "github",
@@ -8157,7 +8157,7 @@
     },
     "packages/crashlytics": {
       "name": "@capacitor-firebase/crashlytics",
-      "version": "6.2.0",
+      "version": "6.1.0",
       "funding": [
         {
           "type": "github",
@@ -8209,7 +8209,7 @@
     },
     "packages/firestore": {
       "name": "@capacitor-firebase/firestore",
-      "version": "6.2.0",
+      "version": "6.1.0",
       "funding": [
         {
           "type": "github",
@@ -8262,7 +8262,7 @@
     },
     "packages/functions": {
       "name": "@capacitor-firebase/functions",
-      "version": "6.2.0",
+      "version": "6.1.0",
       "funding": [
         {
           "type": "github",
@@ -8315,7 +8315,7 @@
     },
     "packages/messaging": {
       "name": "@capacitor-firebase/messaging",
-      "version": "6.2.0",
+      "version": "6.1.0",
       "funding": [
         {
           "type": "github",
@@ -8368,7 +8368,7 @@
     },
     "packages/performance": {
       "name": "@capacitor-firebase/performance",
-      "version": "6.2.0",
+      "version": "6.1.0",
       "funding": [
         {
           "type": "github",
@@ -8421,7 +8421,7 @@
     },
     "packages/remote-config": {
       "name": "@capacitor-firebase/remote-config",
-      "version": "6.2.0",
+      "version": "6.1.0",
       "funding": [
         {
           "type": "github",
@@ -8474,7 +8474,7 @@
     },
     "packages/storage": {
       "name": "@capacitor-firebase/storage",
-      "version": "6.2.0",
+      "version": "6.1.0",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7945,7 +7945,7 @@
     },
     "packages/analytics": {
       "name": "@capacitor-firebase/analytics",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "funding": [
         {
           "type": "github",
@@ -7998,7 +7998,7 @@
     },
     "packages/app": {
       "name": "@capacitor-firebase/app",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "funding": [
         {
           "type": "github",
@@ -8039,7 +8039,7 @@
     },
     "packages/app-check": {
       "name": "@capacitor-firebase/app-check",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "funding": [
         {
           "type": "github",
@@ -8104,7 +8104,7 @@
     },
     "packages/authentication": {
       "name": "@capacitor-firebase/authentication",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "funding": [
         {
           "type": "github",
@@ -8157,7 +8157,7 @@
     },
     "packages/crashlytics": {
       "name": "@capacitor-firebase/crashlytics",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "funding": [
         {
           "type": "github",
@@ -8209,7 +8209,7 @@
     },
     "packages/firestore": {
       "name": "@capacitor-firebase/firestore",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "funding": [
         {
           "type": "github",
@@ -8262,7 +8262,7 @@
     },
     "packages/functions": {
       "name": "@capacitor-firebase/functions",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "funding": [
         {
           "type": "github",
@@ -8315,7 +8315,7 @@
     },
     "packages/messaging": {
       "name": "@capacitor-firebase/messaging",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "funding": [
         {
           "type": "github",
@@ -8368,7 +8368,7 @@
     },
     "packages/performance": {
       "name": "@capacitor-firebase/performance",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "funding": [
         {
           "type": "github",
@@ -8421,7 +8421,7 @@
     },
     "packages/remote-config": {
       "name": "@capacitor-firebase/remote-config",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "funding": [
         {
           "type": "github",
@@ -8474,7 +8474,7 @@
     },
     "packages/storage": {
       "name": "@capacitor-firebase/storage",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "funding": [
         {
           "type": "github",

--- a/packages/analytics/src/web.ts
+++ b/packages/analytics/src/web.ts
@@ -60,7 +60,7 @@ export class FirebaseAnalyticsWeb
 
   public async setUserId(options: SetUserIdOptions): Promise<void> {
     const analytics = getAnalytics();
-    setUserId(analytics, options.userId || '');
+    setUserId(analytics, options.userId);
   }
 
   public async setUserProperty(options: SetUserPropertyOptions): Promise<void> {


### PR DESCRIPTION
Since I've implemented setUserId on a web project, I have less unique visitors than expected. I have some doubts of the implementation of setUserId, which currently set an empty string if we pass a null value.

According to the Firebase JS docs, null is accepted : https://firebase.google.com/docs/reference/js/analytics.md?hl=fr#setuserid_86d82f6
And iOS / Android docs says that userId must be a non empty string : https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics#public-void-setuserid-string-id https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics#public-void-setuserid-string-id

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The changes have been tested successfully.
- [ ] A changeset has been created (`npm run changeset`).
- [ ] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).
