### PR TITLE
feat(functions): Add regionOrCustomDomain option to useEmulator.

### DIFF
--- a/.changeset/cuddly-baboons-add.md
+++ b/.changeset/cuddly-baboons-add.md
@@ -2,4 +2,4 @@
 '@capacitor-firebase/functions': minor
 ---
 
-fix(functions): add `regionOrCustomDomain` option to `UseEmulatorOptions`
+feat(functions): add `regionOrCustomDomain` option to `UseEmulatorOptions`

--- a/.changeset/cuddly-baboons-add.md
+++ b/.changeset/cuddly-baboons-add.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/functions': minor
+---
+
+fix(functions): add `regionOrCustomDomain` option to `UseEmulatorOptions`

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -179,10 +179,11 @@ On Android, the cleartext traffic must be allowed. On the Capacitor configuratio
 
 #### UseEmulatorOptions
 
-| Prop       | Type                | Description                                                                                                                                                                     | Default           | Since |
-| ---------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- | ----- |
-| **`host`** | <code>string</code> | The emulator host without any port or scheme. Note when using a Android Emulator device: 10.0.2.2 is the special IP address to connect to the 'localhost' of the host computer. |                   | 6.1.0 |
-| **`port`** | <code>number</code> | The emulator port.                                                                                                                                                              | <code>5001</code> | 6.1.0 |
+| Prop                       | Type                | Description                                                                                                                                                                     | Default           | Since |
+| -------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- | ----- |
+| **`host`**                 | <code>string</code> | The emulator host without any port or scheme. Note when using a Android Emulator device: 10.0.2.2 is the special IP address to connect to the 'localhost' of the host computer. |                   | 6.1.0 |
+| **`port`**                 | <code>number</code> | The emulator port.                                                                                                                                                              | <code>5001</code> | 6.1.0 |
+| **`regionOrCustomDomain`** | <code>string</code> | one of: a) The region the callable functions are located in (ex: us-central1) b) A custom domain hosting the callable functions (ex: https://mydomain.com)                      |                   |       |
 
 
 ### Type Aliases

--- a/packages/functions/src/definitions.ts
+++ b/packages/functions/src/definitions.ts
@@ -123,4 +123,11 @@ export interface UseEmulatorOptions {
    * @example 5001
    */
   port?: number;
+  /**
+   * The region the callable functions are located in or a custom domain hosting the callable functions.
+   *
+   * @example 'us-central1'
+   * @example 'https://mydomain.com'
+   */
+  regionOrCustomDomain?: string;
 }

--- a/packages/functions/src/web.ts
+++ b/packages/functions/src/web.ts
@@ -48,7 +48,7 @@ export class FirebaseFunctionsWeb
   }
 
   public async useEmulator(options: UseEmulatorOptions): Promise<void> {
-    const functions = getFunctions();
+    const functions = getFunctions(undefined, options.regionOrCustomDomain);
     const port = options.port || 5001;
     connectFunctionsEmulator(functions, options.host, port);
   }


### PR DESCRIPTION
* fix useEmulator for specific region

Introduced a new property `regionOrCustomDomain` to the `UseEmulatorOptions` interface to enable specifying either a region or a custom domain for callable Firebase functions. This change facilitates greater flexibility in configuring the functions emulator based on deployment preferences. Updated related documentation to reflect these changes for clarity.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the issue : https://github.com/capawesome-team/capacitor-firebase/issues/765

Close #765 