### PR TITLE
fix(firestore): Prevent iOS crash caused by concurrency issue

### DIFF
--- a/.changeset/eleven-hornets-joke.md
+++ b/.changeset/eleven-hornets-joke.md
@@ -2,4 +2,4 @@
 '@capacitor-firebase/firestore': patch
 ---
 
-fix(firestore): Prevent iOS crash caused by concurrency issue adding Collection Group Snapshot Listeners
+fix(ios): prevent crash caused by concurrency issue

--- a/.changeset/eleven-hornets-joke.md
+++ b/.changeset/eleven-hornets-joke.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/firestore': patch
+---
+
+fix(firestore): Prevent iOS crash caused by concurrency issue adding Collection Group Snapshot Listeners

--- a/packages/firestore/ios/Plugin/FirebaseFirestore.swift
+++ b/packages/firestore/ios/Plugin/FirebaseFirestore.swift
@@ -2,10 +2,32 @@ import Foundation
 import FirebaseCore
 import FirebaseFirestore
 
+private actor ListenerRegistrationMap {
+    private var listenerRegistrationMap: [String: ListenerRegistration] = [:]
+    
+    func addRegistration(_ listenerRegistration: ListenerRegistration, listenerId: String) async {
+        listenerRegistrationMap[listenerId] = listenerRegistration
+    }
+    
+    func removeRegistration(listenerId: String) async {
+        if let listenerRegistration = listenerRegistrationMap[listenerId] {
+            listenerRegistration.remove()
+        }
+        listenerRegistrationMap.removeValue(forKey: listenerId)
+    }
+    
+    func removeAll() async {
+        listenerRegistrationMap.forEach { _, value in
+            value.remove()
+        }
+        listenerRegistrationMap.removeAll()
+    }
+}
+
 @objc public class FirebaseFirestore: NSObject {
     private let plugin: FirebaseFirestorePlugin
-    private var listenerRegistrationMap: [String: ListenerRegistration] = [:]
-
+    private var listenerRegistrationMap = ListenerRegistrationMap()
+    
     init(plugin: FirebaseFirestorePlugin) {
         self.plugin = plugin
         super.init()
@@ -208,7 +230,9 @@ import FirebaseFirestore
                 completion(result, nil)
             }
         }
-        self.listenerRegistrationMap[callbackId] = listenerRegistration
+        Task {
+            await self.listenerRegistrationMap.addRegistration(listenerRegistration, listenerId: callbackId)
+        }
     }
 
     @objc public func addCollectionSnapshotListener(_ options: AddCollectionSnapshotListenerOptions, completion: @escaping (Result?, Error?) -> Void) {
@@ -241,7 +265,7 @@ import FirebaseFirestore
                         completion(result, nil)
                     }
                 }
-                self.listenerRegistrationMap[callbackId] = listenerRegistration
+                await listenerRegistrationMap.addRegistration(listenerRegistration, listenerId: callbackId)
             } catch {
                 completion(nil, error)
             }
@@ -278,26 +302,19 @@ import FirebaseFirestore
                         completion(result, nil)
                     }
                 }
-                self.listenerRegistrationMap[callbackId] = listenerRegistration
+                await listenerRegistrationMap.addRegistration(listenerRegistration, listenerId: callbackId)
             } catch {
                 completion(nil, error)
             }
         }
     }
 
-    @objc public func removeSnapshotListener(_ options: RemoveSnapshotListenerOptions) {
+    @objc public func removeSnapshotListener(_ options: RemoveSnapshotListenerOptions) async {
         let callbackId = options.getCallbackId()
-
-        if let listenerRegistration = self.listenerRegistrationMap[callbackId] {
-            listenerRegistration.remove()
-        }
-        self.listenerRegistrationMap.removeValue(forKey: callbackId)
+        await listenerRegistrationMap.removeRegistration(listenerId: callbackId)
     }
 
-    @objc public func removeAllListeners() {
-        for listenerRegistration in self.listenerRegistrationMap.values {
-            listenerRegistration.remove()
-        }
-        self.listenerRegistrationMap.removeAll()
+    @objc public func removeAllListeners() async {
+        await self.listenerRegistrationMap.removeAll()
     }
 }

--- a/packages/firestore/ios/Plugin/FirebaseFirestore.swift
+++ b/packages/firestore/ios/Plugin/FirebaseFirestore.swift
@@ -309,12 +309,18 @@ private actor ListenerRegistrationMap {
         }
     }
 
-    @objc public func removeSnapshotListener(_ options: RemoveSnapshotListenerOptions) async {
+    @objc public func removeSnapshotListener(_ options: RemoveSnapshotListenerOptions, completion: @escaping () -> Void) {
         let callbackId = options.getCallbackId()
-        await listenerRegistrationMap.removeRegistration(listenerId: callbackId)
+        Task {
+            await listenerRegistrationMap.removeRegistration(listenerId: callbackId)
+            completion()
+        }
     }
 
-    @objc public func removeAllListeners() async {
-        await self.listenerRegistrationMap.removeAll()
+    @objc public func removeAllListeners(completion: @escaping () -> Void) {
+        Task {
+            await listenerRegistrationMap.removeAll()
+            completion()
+        }
     }
 }

--- a/packages/firestore/ios/Plugin/FirebaseFirestorePlugin.swift
+++ b/packages/firestore/ios/Plugin/FirebaseFirestorePlugin.swift
@@ -358,10 +358,9 @@ public class FirebaseFirestorePlugin: CAPPlugin {
             bridge?.releaseCall(savedCall)
         }
         self.pluginCallMap.removeAll()
-        self.eventListeners?.removeAllObjects()
         
         implementation?.removeAllListeners {
-            call.resolve()
+            super.removeAllListeners(call)
         }
     }
 }

--- a/packages/firestore/ios/Plugin/FirebaseFirestorePlugin.swift
+++ b/packages/firestore/ios/Plugin/FirebaseFirestorePlugin.swift
@@ -348,8 +348,7 @@ public class FirebaseFirestorePlugin: CAPPlugin {
 
         let options = RemoveSnapshotListenerOptions(callbackId: callbackId)
 
-        Task {
-            await implementation?.removeSnapshotListener(options)
+        implementation?.removeSnapshotListener(options) {
             call.resolve()
         }
     }
@@ -359,10 +358,10 @@ public class FirebaseFirestorePlugin: CAPPlugin {
             bridge?.releaseCall(savedCall)
         }
         self.pluginCallMap.removeAll()
-
-        Task {
-            await implementation?.removeAllListeners()
+        self.eventListeners?.removeAllObjects()
+        
+        implementation?.removeAllListeners {
+            call.resolve()
         }
-        super.removeAllListeners(call)
     }
 }

--- a/packages/firestore/ios/Plugin/FirebaseFirestorePlugin.swift
+++ b/packages/firestore/ios/Plugin/FirebaseFirestorePlugin.swift
@@ -358,9 +358,10 @@ public class FirebaseFirestorePlugin: CAPPlugin {
             bridge?.releaseCall(savedCall)
         }
         self.pluginCallMap.removeAll()
+        self.eventListeners?.removeAllObjects()
         
         implementation?.removeAllListeners {
-            super.removeAllListeners(call)
+            call.resolve()
         }
     }
 }

--- a/packages/firestore/ios/Plugin/FirebaseFirestorePlugin.swift
+++ b/packages/firestore/ios/Plugin/FirebaseFirestorePlugin.swift
@@ -348,8 +348,10 @@ public class FirebaseFirestorePlugin: CAPPlugin {
 
         let options = RemoveSnapshotListenerOptions(callbackId: callbackId)
 
-        implementation?.removeSnapshotListener(options)
-        call.resolve()
+        Task {
+            await implementation?.removeSnapshotListener(options)
+            call.resolve()
+        }
     }
 
     @objc override public func removeAllListeners(_ call: CAPPluginCall) {
@@ -358,7 +360,9 @@ public class FirebaseFirestorePlugin: CAPPlugin {
         }
         self.pluginCallMap.removeAll()
 
-        implementation?.removeAllListeners()
+        Task {
+            await implementation?.removeAllListeners()
+        }
         super.removeAllListeners(call)
     }
 }


### PR DESCRIPTION
Close #771

Wraps the `listenerRegistrationMap` in an actor to manage the reading and writing in a thread-safe way. It is necessary because `addCollectionSnapshotListener` and `addCollectionGroupSnapshotListener` dispatch a Task in order to build the constraints but then immediately write to the `listenerRegistrationMap` within that Task.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).
