### PR TITLE
fix(authentication): mark `actionCodeSettings` option as optional

### DIFF
--- a/.changeset/wild-pianos-check.md
+++ b/.changeset/wild-pianos-check.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/authentication': patch
+---
+
+fix(authentication): mark `actionCodeSettings` option as optional

--- a/packages/app-check/ios/Plugin/FirebaseAppCheckPlugin.swift
+++ b/packages/app-check/ios/Plugin/FirebaseAppCheckPlugin.swift
@@ -53,7 +53,7 @@ public class FirebaseAppCheckPlugin: CAPPlugin, CAPBridgedPlugin {
         } else {
             hasDebugToken = call.getBool("debug", false)
         }
-        
+
         let isTokenAutoRefreshEnabled = call.getBool("isTokenAutoRefreshEnabled") ?? false
         implementation?.initialize(debug: hasDebugToken)
         implementation?.setTokenAutoRefreshEnabled(isTokenAutoRefreshEnabled)

--- a/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthentication.java
+++ b/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthentication.java
@@ -560,13 +560,16 @@ public class FirebaseAuthentication {
     public void verifyBeforeUpdateEmail(
         FirebaseUser user,
         @NonNull String newEmail,
-        @NonNull ActionCodeSettings actionCodeSettings,
+        @Nullable ActionCodeSettings actionCodeSettings,
         @NonNull EmptyResultCallback callback
     ) {
-        user
-            .verifyBeforeUpdateEmail(newEmail, actionCodeSettings)
-            .addOnSuccessListener(unused -> callback.success())
-            .addOnFailureListener(exception -> callback.error(exception));
+        Task<Void> task;
+        if (actionCodeSettings == null) {
+            task = user.verifyBeforeUpdateEmail(newEmail);
+        } else {
+            task = user.verifyBeforeUpdateEmail(newEmail, actionCodeSettings);
+        }
+        task.addOnSuccessListener(unused -> callback.success()).addOnFailureListener(exception -> callback.error(exception));
     }
 
     public void updatePassword(FirebaseUser user, @NonNull String newPassword, @NonNull Runnable callback) {

--- a/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthenticationPlugin.java
+++ b/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthenticationPlugin.java
@@ -859,11 +859,9 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             }
 
             JSObject settings = call.getObject("actionCodeSettings");
-            if (settings == null) {
-                call.reject(ERROR_ACTION_CODE_SETTINGS_MISSING);
-                return;
-            }
-            ActionCodeSettings actionCodeSettings = FirebaseAuthenticationHelper.createActionCodeSettings(settings);
+            ActionCodeSettings actionCodeSettings = settings == null
+                ? null
+                : FirebaseAuthenticationHelper.createActionCodeSettings(settings);
 
             EmptyResultCallback callback = new EmptyResultCallback() {
                 @Override

--- a/packages/authentication/ios/Plugin/FirebaseAuthentication.swift
+++ b/packages/authentication/ios/Plugin/FirebaseAuthentication.swift
@@ -269,7 +269,7 @@ public typealias AuthStateChangedObserver = () -> Void
         }
     }
 
-    @objc func verifyBeforeUpdateEmail(_ newEmail: String, actionCodeSettings: ActionCodeSettings, completion: @escaping (Error?) -> Void) {
+    @objc func verifyBeforeUpdateEmail(_ newEmail: String, actionCodeSettings: ActionCodeSettings?, completion: @escaping (Error?) -> Void) {
         guard let user = self.getCurrentUser() else {
             completion(RuntimeError(plugin.errorNoUserSignedIn))
             return
@@ -279,7 +279,11 @@ public typealias AuthStateChangedObserver = () -> Void
             completion(error)
         }
 
-        user.sendEmailVerification(beforeUpdatingEmail: newEmail, actionCodeSettings: actionCodeSettings, completion: completion)
+        if let actionCodeSettings = actionCodeSettings {
+            user.sendEmailVerification(beforeUpdatingEmail: newEmail, actionCodeSettings: actionCodeSettings, completion: completion)
+        } else {
+            user.sendEmailVerification(beforeUpdatingEmail: newEmail, completion: completion)
+        }
     }
 
     @objc func sendPasswordResetEmail(_ options: SendPasswordResetEmailOptions, completion: @escaping (Error?) -> Void) {

--- a/packages/authentication/ios/Plugin/FirebaseAuthenticationPlugin.swift
+++ b/packages/authentication/ios/Plugin/FirebaseAuthenticationPlugin.swift
@@ -570,14 +570,10 @@ public class FirebaseAuthenticationPlugin: CAPPlugin, CAPBridgedPlugin {
             return
         }
 
-        guard let actionCodeSettingsDict = call.getObject("actionCodeSettings") else {
-            call.reject(errorActionCodeSettingsMissing)
-            return
-        }
-        guard let actionCodeSettings = FirebaseAuthenticationHelper.createActionCodeSettings(actionCodeSettingsDict) else {
-            call.reject(errorActionCodeSettingsMissing)
-            return
-        }
+        let actionCodeSettingsDict = call.getObject("actionCodeSettings")
+        let actionCodeSettings: ActionCodeSettings? = actionCodeSettingsDict != nil
+            ? FirebaseAuthenticationHelper.createActionCodeSettings(actionCodeSettingsDict!)
+            : nil
 
         implementation?.verifyBeforeUpdateEmail(newEmail, actionCodeSettings: actionCodeSettings, completion: { error in
             if let error = error {

--- a/packages/authentication/src/definitions.ts
+++ b/packages/authentication/src/definitions.ts
@@ -814,7 +814,7 @@ export interface VerifyBeforeUpdateEmailOptions {
    *
    * @since 6.3.0
    */
-  actionCodeSettings: ActionCodeSettings;
+  actionCodeSettings?: ActionCodeSettings;
 }
 
 /**


### PR DESCRIPTION
Regarding #831, the `verifyBeforeUpdateEmail()` function was added by @ewwwgiddings in #741.

After integration, I discovered that the `actionCodeSettings` parameter in `verifyBeforeUpdateEmail()` is optional according to the flow design and documentation.

Without it, a verification email will be sent without dynamic links functionality to open the link in the app.

- iOS: https://firebase.google.com/docs/reference/swift/firebaseauth/api/reference/Classes/User#/c:@M@FirebaseAuth@objc(cs)FIRUser(im)sendEmailVerificationBeforeUpdatingEmail:actionCodeSettings:completion:
- Android: https://firebase.google.com/docs/reference/android/com/google/firebase/auth/FirebaseUser#verifyBeforeUpdateEmail(java.lang.String)
- Web: https://firebase.google.com/docs/reference/node/firebase.User#verifybeforeupdateemail

Screenshots below:

<img width="740" alt="image" src="https://github.com/user-attachments/assets/a3616505-bef3-4dc2-995b-893708372ea1" />

<img width="714" alt="image" src="https://github.com/user-attachments/assets/62b223b1-ebfe-4f15-b1c4-2c8a19540669" />

<img width="962" alt="image" src="https://github.com/user-attachments/assets/c26fba05-f4cc-448b-b29d-8778f60d1093" />

On the other hand, it is required in `sendSignInLinkToEmail()`:

- iOS: https://firebase.google.com/docs/reference/swift/firebaseauth/api/reference/Classes/Auth#/c:@M@FirebaseAuth@objc(cs)FIRAuth(im)sendSignInLinkToEmail:actionCodeSettings:completion:
- Android: https://firebase.google.com/docs/reference/android/com/google/firebase/auth/FirebaseAuth#sendSignInLinkToEmail(java.lang.String,com.google.firebase.auth.ActionCodeSettings)
- Web: https://firebase.google.com/docs/reference/node/firebase.auth.Auth#sendsigninlinktoemail

The changes in `packages/app-check/ios/Plugin/FirebaseAppCheckPlugin.swift` is generated by `npm run fmt` and I think I should commit it.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).
