### PR TITLE
fix(messaging): `tokenReceived` event did not always contain a token

### DIFF
--- a/.changeset/rare-pigs-divide.md
+++ b/.changeset/rare-pigs-divide.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/messaging': patch
+---
+
+fix(ios): `tokenReceived` event did not always contain a token

--- a/packages/messaging/ios/Plugin/FirebaseMessagingPlugin.swift
+++ b/packages/messaging/ios/Plugin/FirebaseMessagingPlugin.swift
@@ -177,6 +177,9 @@ public class FirebaseMessagingPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     func handleTokenReceived(token: String?) {
+        guard let token = token else {
+            return
+        }
         var result = JSObject()
         result["token"] = token
         notifyListeners(tokenReceivedEvent, data: result, retainUntilConsumed: true)


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The changes have been tested successfully.
- [ ] A changeset has been created (`npm run changeset`).
- [ ] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).
