### PR TITLE
feat: supports debugging native applications

### DIFF
--- a/.changeset/violet-jeans-share.md
+++ b/.changeset/violet-jeans-share.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/app-check': minor
+---
+
+feat: support debug providers on native apps

--- a/packages/app-check/android/build.gradle
+++ b/packages/app-check/android/build.gradle
@@ -5,6 +5,7 @@ ext {
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.6.1'
     firebaseAppCheckPlayIntegrityVersion = project.hasProperty('firebaseAppCheckPlayIntegrityVersion') ? rootProject.ext.firebaseAppCheckPlayIntegrityVersion : '18.0.0'
     firebaseAppCheckDebugVersion = project.hasProperty('firebaseAppCheckDebugVersion') ? rootProject.ext.firebaseAppCheckDebugVersion : '18.0.0'
+    useAppCheckDebugOnDebugBuilds = project.hasProperty('useAppCheckDebugOnDebugBuilds') ? rootProject.ext.useAppCheckDebugOnDebugBuilds : true
 }
 
 buildscript {
@@ -29,10 +30,17 @@ android {
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+    buildFeatures {
+        buildConfig true
+    }
     buildTypes {
+        debug {
+            buildConfigField "boolean", "USE_APP_CHECK_DEBUG", "${useAppCheckDebugOnDebugBuilds}"
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            buildConfigField "boolean", "USE_APP_CHECK_DEBUG", "false"
         }
     }
     lintOptions {

--- a/packages/app-check/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/appcheck/FirebaseAppCheck.java
+++ b/packages/app-check/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/appcheck/FirebaseAppCheck.java
@@ -33,7 +33,7 @@ public class FirebaseAppCheck {
     }
 
     public void initialize(boolean debug, boolean isTokenAutoRefreshEnabled) {
-        if (debug) {
+        if (debug || BuildConfig.USE_APP_CHECK_DEBUG) {
             getFirebaseAppCheckInstance()
                 .installAppCheckProviderFactory(DebugAppCheckProviderFactory.getInstance(), isTokenAutoRefreshEnabled);
         } else {

--- a/packages/app-check/ios/Plugin/FirebaseAppCheck.swift
+++ b/packages/app-check/ios/Plugin/FirebaseAppCheck.swift
@@ -4,32 +4,60 @@ import FirebaseCore
 import FirebaseAppCheck
 
 @objc public class FirebaseAppCheck: NSObject {
+    @objc public static let shared = FirebaseAppCheck()
 
-    override public init() {
+    @objc public override init() {
+        super.init()
+    }
+
+    @objc private func configureFirebase() {
         if FirebaseApp.app() == nil {
             FirebaseApp.configure()
         }
     }
-
-    @objc public func getToken(forceRefresh: Bool, completion: @escaping (String?, Int, Error?) -> Void) {
-        AppCheck.appCheck().token(forcingRefresh: forceRefresh, completion: { result, error in
-            if let error = error {
-                completion(nil, 0, error)
-                return
-            }
-            var expireTimeMillis: Int = 0
-            if let result = result {
-                expireTimeMillis = Int(result.expirationDate.timeIntervalSince1970) * 1000
-            }
-            completion(result?.token, expireTimeMillis, nil)
-        })
+    @objc public func getToken(
+        forceRefresh: Bool, completion: @escaping (String?, Int, Error?) -> Void
+    ) {
+        AppCheck.appCheck().token(
+            forcingRefresh: forceRefresh,
+            completion: { result, error in
+                if let error = error {
+                    completion(nil, 0, error)
+                    return
+                }
+                var expireTimeMillis: Int = 0
+                if let result = result {
+                    expireTimeMillis = Int(result.expirationDate.timeIntervalSince1970) * 1000
+                }
+                completion(result?.token, expireTimeMillis, nil)
+            })
     }
 
     @objc public func initialize(debug: Bool) {
-        if debug {
+        let firebaseApp = FirebaseApp.app()
+        if firebaseApp != nil {
+            print(
+                "FirebaseAppCheck",
+                "Firebase application already defined, can't launch App Check again, read more from plugin's documentation"
+            )
+            return
+        }
+
+        if (debug) {
+            let isDebugLoggingEnabled = ProcessInfo.processInfo.arguments.contains(
+                "-FIRDebugEnabled")
+            if (!isDebugLoggingEnabled) {
+                print(
+                    "FirebaseAppCheck",
+                    "Enable -FIRDebugEnabled in scheme arguments to print AppCheck debug token")
+            }
+
+            print("FirebaseAppCheck", "Setting Firebase App Check to debug mode")
             AppCheck.setAppCheckProviderFactory(AppCheckDebugProviderFactory())
+            configureFirebase()
         } else {
             AppCheck.setAppCheckProviderFactory(CustomAppCheckProviderFactory())
+            configureFirebase()
         }
     }
 

--- a/packages/app-check/src/definitions.ts
+++ b/packages/app-check/src/definitions.ts
@@ -97,15 +97,15 @@ export interface InitializeOptions {
   /**
    * If `true`, the debug provider is used.
    *
-   * On **Web**, you can also set a predefined debug token string instead of `true`. On Android and iOS, you have to use environment variables for this.
+   * On **Web**, you can also set a predefined debug token string instead of `true`. On **Android** and **iOS** refer to the [documentation](#debug-mode-for-app-check) for more information.
    *
    * ⚠️ **Attention**: The debug provider allows access to your Firebase resources from unverified devices.
    * Don't use the debug provider in production builds of your app, and don't share your debug builds with untrusted parties.
    *
    * @since 7.1.0
    * @default false
-   * @see https://firebase.google.com/docs/app-check/android/debug-provider#ci
-   * @see https://firebase.google.com/docs/app-check/ios/debug-provider#ci
+   * @see https://firebase.google.com/docs/app-check/android/debug-provider
+   * @see https://firebase.google.com/docs/app-check/ios/debug-provider
    * @see https://firebase.google.com/docs/app-check/web/debug-provider
    */
   debugToken?: boolean | string;


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

## Description
This is a workaround feature for issue #453 before v8.0.0 is here.

This pull request introduces support for enabling debug mode in Firebase App Check on Android and iOS correctly.
On iOS, it was not yet possible without manual code within `AppDelegation.swift`, as there can be multiple points at which `FirebaseApp` is configured. The App Check factory provider needed to be set before the Firebase app.

Debug usage has been documented on README.md for each use case with examples (as they differs a bit).