### PR TITLE
fix(authentication): `timeout` option was ignored in `signInWithPhoneNumber` method

### DIFF
--- a/.changeset/curly-scissors-buy.md
+++ b/.changeset/curly-scissors-buy.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/authentication': major
+---
+
+fix(android): timeout option was ignored in signInWithPhoneNumber method.

--- a/.changeset/curly-scissors-buy.md
+++ b/.changeset/curly-scissors-buy.md
@@ -1,5 +1,5 @@
 ---
-'@capacitor-firebase/authentication': major
+'@capacitor-firebase/authentication': patch
 ---
 
-fix(android): timeout option was ignored in signInWithPhoneNumber method.
+fix(android): timeout option was ignored in signInWithPhoneNumber method

--- a/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthenticationPlugin.java
+++ b/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthenticationPlugin.java
@@ -745,7 +745,7 @@ public class FirebaseAuthenticationPlugin extends Plugin {
                 return;
             }
             boolean resendCode = call.getBoolean("resendCode", false);
-            Long timeout = call.getLong("timeout", 60L);
+            Long timeout = call.getInt("timeout", 60).longValue();
             SignInWithPhoneNumberOptions options = new SignInWithPhoneNumberOptions(skipNativeAuth, phoneNumber, resendCode, timeout);
 
             implementation.signInWithPhoneNumber(options);


### PR DESCRIPTION
Fix that timeout is always at 60

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [X] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

The Issue #906