### PR TITLE
fix(authentication): handle iOS 26 FirebaseApp.configure() crash

### DIFF
--- a/packages/authentication/ios/Plugin/FirebaseAuthentication.swift
+++ b/packages/authentication/ios/Plugin/FirebaseAuthentication.swift
@@ -22,8 +22,14 @@ public typealias AuthStateChangedObserver = () -> Void
         self.plugin = plugin
         self.config = config
         super.init()
+        // iOS 26 beta bug workaround: FirebaseApp.app() can return nil even when
+        // Firebase is already auto-configured from GoogleService-Info.plist.
+        // Use ObjC exception handler to catch the "already configured" exception.
         if FirebaseApp.app() == nil {
-            FirebaseApp.configure()
+            var error: NSError?
+            ObjCExceptionCatcher.tryBlock({
+                FirebaseApp.configure()
+            }, error: &error)
         }
         self.initAuthProviderHandlers(config: config)
         Auth.auth().addStateDidChangeListener {_, _ in

--- a/packages/authentication/ios/Plugin/ObjCExceptionCatcher.h
+++ b/packages/authentication/ios/Plugin/ObjCExceptionCatcher.h
@@ -1,0 +1,17 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Helper class to catch Objective-C exceptions from Swift.
+/// Swift cannot catch NSException, so we need an ObjC bridge for exception handling.
+@interface ObjCExceptionCatcher : NSObject
+
+/// Executes a block and catches any Objective-C exceptions.
+/// @param block The block to execute.
+/// @param error On return, contains the error if an exception was thrown.
+/// @return YES if the block executed successfully, NO if an exception was caught.
++ (BOOL)tryBlock:(void (NS_NOESCAPE ^)(void))block error:(NSError * _Nullable * _Nullable)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/authentication/ios/Plugin/ObjCExceptionCatcher.m
+++ b/packages/authentication/ios/Plugin/ObjCExceptionCatcher.m
@@ -1,0 +1,24 @@
+#import "ObjCExceptionCatcher.h"
+
+@implementation ObjCExceptionCatcher
+
++ (BOOL)tryBlock:(void (NS_NOESCAPE ^)(void))block error:(NSError * _Nullable * _Nullable)error {
+    @try {
+        block();
+        return YES;
+    }
+    @catch (NSException *exception) {
+        if (error) {
+            *error = [NSError errorWithDomain:@"ObjCExceptionCatcher"
+                                         code:1
+                                     userInfo:@{
+                NSLocalizedDescriptionKey: exception.reason ?: @"Unknown exception",
+                @"ExceptionName": exception.name ?: @"Unknown",
+                @"ExceptionReason": exception.reason ?: @"Unknown"
+            }];
+        }
+        return NO;
+    }
+}
+
+@end


### PR DESCRIPTION
## Summary

Fixes #947

On iOS 26, `FirebaseApp.app()` can return `nil` even when Firebase has already been auto-configured from `GoogleService-Info.plist`. This causes the plugin's `FirebaseApp.configure()` call to throw an Objective-C exception ("Default app has already been configured"), which crashes the app since Swift cannot catch `NSException`.

## Root Cause

The existing code in `FirebaseAuthentication.swift`:

```swift
if FirebaseApp.app() == nil {
    FirebaseApp.configure()
}
```

Fails on iOS 26 because:
1. `FirebaseApp.app()` incorrectly returns `nil` (iOS 26 bug)
2. `FirebaseApp.configure()` is called
3. Firebase throws `NSException` because it's already configured
4. Swift cannot catch Objective-C exceptions → crash

## Solution

Add an Objective-C helper class (`ObjCExceptionCatcher`) that wraps the `configure()` call in `@try/@catch`, allowing the exception to be caught gracefully if Firebase is already configured.

## Changes

- **`ObjCExceptionCatcher.h/.m`** - New ObjC helper class to catch `NSException` from Swift
- **`FirebaseAuthentication.swift`** - Wrap `FirebaseApp.configure()` in exception handler

## Testing

Tested on:
- ✅ iOS 26.1 simulator (iPhone 17 Pro) - Previously crashed, now works
- ✅ iOS 18 simulator - Still works (no regression)

## Notes

This same pattern exists in other packages (`messaging`, `analytics`, `app-check`, `app`). If this fix is accepted, similar changes could be applied to those packages as well.