### PR TITLE
fix: AGP 9.0 no longer supports `proguard-android.txt`

### DIFF
--- a/.changeset/spicy-dryers-poke.md
+++ b/.changeset/spicy-dryers-poke.md
@@ -1,0 +1,15 @@
+---
+'@capacitor-firebase/authentication': patch
+'@capacitor-firebase/remote-config': patch
+'@capacitor-firebase/crashlytics': patch
+'@capacitor-firebase/performance': patch
+'@capacitor-firebase/analytics': patch
+'@capacitor-firebase/app-check': patch
+'@capacitor-firebase/firestore': patch
+'@capacitor-firebase/functions': patch
+'@capacitor-firebase/messaging': patch
+'@capacitor-firebase/storage': patch
+'@capacitor-firebase/app': patch
+---
+
+fix(android): AGP 9.0 no longer supports `proguard-android.txt`

--- a/packages/analytics/android/build.gradle
+++ b/packages/analytics/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/app-check/android/build.gradle
+++ b/packages/app-check/android/build.gradle
@@ -32,7 +32,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/app/android/build.gradle
+++ b/packages/app/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/authentication/android/build.gradle
+++ b/packages/authentication/android/build.gradle
@@ -38,7 +38,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/crashlytics/android/build.gradle
+++ b/packages/crashlytics/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/firestore/android/build.gradle
+++ b/packages/firestore/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/functions/android/build.gradle
+++ b/packages/functions/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/messaging/android/build.gradle
+++ b/packages/messaging/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/performance/android/build.gradle
+++ b/packages/performance/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/remote-config/android/build.gradle
+++ b/packages/remote-config/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/storage/android/build.gradle
+++ b/packages/storage/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {


### PR DESCRIPTION
See https://github.com/ionic-team/capacitor/pull/8315

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The changes have been tested successfully.
- [ ] A changeset has been created (`npm run changeset`).
- [ ] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).
