### PR TITLE
chore: fix swiftlint scanning dependency files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       ],
       "devDependencies": {
         "@changesets/cli": "2.29.8",
+        "@ionic/swiftlint-config": "2.0.0",
         "@robingenz/changelog-github": "0.0.1",
         "patch-package": "8.0.1",
         "pkg-pr-new": "0.0.20",
@@ -8459,7 +8460,7 @@
     },
     "packages/analytics": {
       "name": "@capacitor-firebase/analytics",
-      "version": "8.0.1",
+      "version": "8.1.0",
       "funding": [
         {
           "type": "github",
@@ -8478,7 +8479,6 @@
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
-        "@ionic/swiftlint-config": "2.0.0",
         "eslint": "8.57.0",
         "firebase": "11.2.0",
         "prettier": "3.4.2",
@@ -8516,7 +8516,7 @@
     },
     "packages/app": {
       "name": "@capacitor-firebase/app",
-      "version": "8.0.1",
+      "version": "8.1.0",
       "funding": [
         {
           "type": "github",
@@ -8535,7 +8535,6 @@
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
-        "@ionic/swiftlint-config": "2.0.0",
         "eslint": "8.57.0",
         "firebase": "11.2.0",
         "prettier": "3.4.2",
@@ -8557,7 +8556,7 @@
     },
     "packages/app-check": {
       "name": "@capacitor-firebase/app-check",
-      "version": "8.0.1",
+      "version": "8.1.0",
       "funding": [
         {
           "type": "github",
@@ -8576,7 +8575,6 @@
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
-        "@ionic/swiftlint-config": "2.0.0",
         "eslint": "8.57.0",
         "firebase": "11.2.0",
         "prettier": "3.4.2",
@@ -8630,7 +8628,7 @@
     },
     "packages/authentication": {
       "name": "@capacitor-firebase/authentication",
-      "version": "8.0.1",
+      "version": "8.1.0",
       "funding": [
         {
           "type": "github",
@@ -8649,7 +8647,6 @@
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
-        "@ionic/swiftlint-config": "2.0.0",
         "eslint": "8.57.0",
         "firebase": "11.2.0",
         "prettier": "3.4.2",
@@ -8687,7 +8684,7 @@
     },
     "packages/crashlytics": {
       "name": "@capacitor-firebase/crashlytics",
-      "version": "8.0.1",
+      "version": "8.1.0",
       "funding": [
         {
           "type": "github",
@@ -8706,7 +8703,6 @@
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
-        "@ionic/swiftlint-config": "2.0.0",
         "eslint": "8.57.0",
         "firebase": "11.2.0",
         "prettier": "3.4.2",
@@ -8743,7 +8739,7 @@
     },
     "packages/firestore": {
       "name": "@capacitor-firebase/firestore",
-      "version": "8.0.1",
+      "version": "8.1.0",
       "funding": [
         {
           "type": "github",
@@ -8762,7 +8758,6 @@
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
-        "@ionic/swiftlint-config": "2.0.0",
         "eslint": "8.57.0",
         "firebase": "11.2.0",
         "prettier": "3.4.2",
@@ -8800,7 +8795,7 @@
     },
     "packages/functions": {
       "name": "@capacitor-firebase/functions",
-      "version": "8.0.1",
+      "version": "8.1.0",
       "funding": [
         {
           "type": "github",
@@ -8819,7 +8814,6 @@
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
-        "@ionic/swiftlint-config": "2.0.0",
         "eslint": "8.57.0",
         "firebase": "11.2.0",
         "prettier": "3.4.2",
@@ -8857,7 +8851,7 @@
     },
     "packages/messaging": {
       "name": "@capacitor-firebase/messaging",
-      "version": "8.0.1",
+      "version": "8.1.0",
       "funding": [
         {
           "type": "github",
@@ -8876,7 +8870,6 @@
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
-        "@ionic/swiftlint-config": "2.0.0",
         "eslint": "8.57.0",
         "firebase": "11.2.0",
         "prettier": "3.4.2",
@@ -8914,7 +8907,7 @@
     },
     "packages/performance": {
       "name": "@capacitor-firebase/performance",
-      "version": "8.0.1",
+      "version": "8.1.0",
       "funding": [
         {
           "type": "github",
@@ -8933,7 +8926,6 @@
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
-        "@ionic/swiftlint-config": "2.0.0",
         "eslint": "8.57.0",
         "firebase": "11.2.0",
         "prettier": "3.4.2",
@@ -8971,7 +8963,7 @@
     },
     "packages/remote-config": {
       "name": "@capacitor-firebase/remote-config",
-      "version": "8.0.1",
+      "version": "8.1.0",
       "funding": [
         {
           "type": "github",
@@ -8990,7 +8982,6 @@
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
-        "@ionic/swiftlint-config": "2.0.0",
         "eslint": "8.57.0",
         "firebase": "11.2.0",
         "prettier": "3.4.2",
@@ -9028,7 +9019,7 @@
     },
     "packages/storage": {
       "name": "@capacitor-firebase/storage",
-      "version": "8.0.1",
+      "version": "8.1.0",
       "funding": [
         {
           "type": "github",
@@ -9047,7 +9038,6 @@
         "@capacitor/docgen": "0.3.1",
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
-        "@ionic/swiftlint-config": "2.0.0",
         "eslint": "8.57.0",
         "firebase": "11.2.0",
         "prettier": "3.4.2",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "2.29.8",
+    "@ionic/swiftlint-config": "2.0.0",
     "@robingenz/changelog-github": "0.0.1",
     "patch-package": "8.0.1",
     "pkg-pr-new": "0.0.20",

--- a/packages/analytics/.swiftlintrc.js
+++ b/packages/analytics/.swiftlintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('../../swiftlint.config.js');

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -64,7 +64,6 @@
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
-    "@ionic/swiftlint-config": "2.0.0",
     "eslint": "8.57.0",
     "firebase": "11.2.0",
     "prettier": "3.4.2",
@@ -83,7 +82,6 @@
       "optional": true
     }
   },
-  "swiftlint": "@ionic/swiftlint-config",
   "eslintConfig": {
     "extends": "@ionic/eslint-config/recommended"
   },

--- a/packages/app-check/.swiftlintrc.js
+++ b/packages/app-check/.swiftlintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('../../swiftlint.config.js');

--- a/packages/app-check/package.json
+++ b/packages/app-check/package.json
@@ -64,7 +64,6 @@
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
-    "@ionic/swiftlint-config": "2.0.0",
     "eslint": "8.57.0",
     "firebase": "11.2.0",
     "prettier": "3.4.2",
@@ -83,7 +82,6 @@
       "optional": true
     }
   },
-  "swiftlint": "@ionic/swiftlint-config",
   "eslintConfig": {
     "extends": "@ionic/eslint-config/recommended"
   },

--- a/packages/app/.swiftlintrc.js
+++ b/packages/app/.swiftlintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('../../swiftlint.config.js');

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -64,7 +64,6 @@
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
-    "@ionic/swiftlint-config": "2.0.0",
     "eslint": "8.57.0",
     "firebase": "11.2.0",
     "prettier": "3.4.2",
@@ -83,7 +82,6 @@
       "optional": true
     }
   },
-  "swiftlint": "@ionic/swiftlint-config",
   "eslintConfig": {
     "extends": "@ionic/eslint-config/recommended"
   },

--- a/packages/authentication/.swiftlintrc.js
+++ b/packages/authentication/.swiftlintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('../../swiftlint.config.js');

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -64,7 +64,6 @@
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
-    "@ionic/swiftlint-config": "2.0.0",
     "eslint": "8.57.0",
     "firebase": "11.2.0",
     "prettier": "3.4.2",
@@ -83,7 +82,6 @@
       "optional": true
     }
   },
-  "swiftlint": "@ionic/swiftlint-config",
   "eslintConfig": {
     "extends": "@ionic/eslint-config/recommended"
   },

--- a/packages/crashlytics/.swiftlintrc.js
+++ b/packages/crashlytics/.swiftlintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('../../swiftlint.config.js');

--- a/packages/crashlytics/package.json
+++ b/packages/crashlytics/package.json
@@ -64,7 +64,6 @@
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
-    "@ionic/swiftlint-config": "2.0.0",
     "eslint": "8.57.0",
     "firebase": "11.2.0",
     "prettier": "3.4.2",
@@ -82,7 +81,6 @@
       "optional": true
     }
   },
-  "swiftlint": "@ionic/swiftlint-config",
   "eslintConfig": {
     "extends": "@ionic/eslint-config/recommended"
   },

--- a/packages/firestore/.swiftlintrc.js
+++ b/packages/firestore/.swiftlintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('../../swiftlint.config.js');

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -64,7 +64,6 @@
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
-    "@ionic/swiftlint-config": "2.0.0",
     "eslint": "8.57.0",
     "firebase": "11.2.0",
     "prettier": "3.4.2",
@@ -83,7 +82,6 @@
       "optional": true
     }
   },
-  "swiftlint": "@ionic/swiftlint-config",
   "eslintConfig": {
     "extends": "@ionic/eslint-config/recommended"
   },

--- a/packages/functions/.swiftlintrc.js
+++ b/packages/functions/.swiftlintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('../../swiftlint.config.js');

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -64,7 +64,6 @@
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
-    "@ionic/swiftlint-config": "2.0.0",
     "eslint": "8.57.0",
     "firebase": "11.2.0",
     "prettier": "3.4.2",
@@ -83,7 +82,6 @@
       "optional": true
     }
   },
-  "swiftlint": "@ionic/swiftlint-config",
   "eslintConfig": {
     "extends": "@ionic/eslint-config/recommended"
   },

--- a/packages/messaging/.swiftlintrc.js
+++ b/packages/messaging/.swiftlintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('../../swiftlint.config.js');

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -64,7 +64,6 @@
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
-    "@ionic/swiftlint-config": "2.0.0",
     "eslint": "8.57.0",
     "firebase": "11.2.0",
     "prettier": "3.4.2",
@@ -83,7 +82,6 @@
       "optional": true
     }
   },
-  "swiftlint": "@ionic/swiftlint-config",
   "eslintConfig": {
     "extends": "@ionic/eslint-config/recommended"
   },

--- a/packages/performance/.swiftlintrc.js
+++ b/packages/performance/.swiftlintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('../../swiftlint.config.js');

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -64,7 +64,6 @@
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
-    "@ionic/swiftlint-config": "2.0.0",
     "eslint": "8.57.0",
     "firebase": "11.2.0",
     "prettier": "3.4.2",
@@ -83,7 +82,6 @@
       "optional": true
     }
   },
-  "swiftlint": "@ionic/swiftlint-config",
   "eslintConfig": {
     "extends": "@ionic/eslint-config/recommended"
   },

--- a/packages/remote-config/.swiftlintrc.js
+++ b/packages/remote-config/.swiftlintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('../../swiftlint.config.js');

--- a/packages/remote-config/package.json
+++ b/packages/remote-config/package.json
@@ -64,7 +64,6 @@
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
-    "@ionic/swiftlint-config": "2.0.0",
     "eslint": "8.57.0",
     "firebase": "11.2.0",
     "prettier": "3.4.2",
@@ -83,7 +82,6 @@
       "optional": true
     }
   },
-  "swiftlint": "@ionic/swiftlint-config",
   "eslintConfig": {
     "extends": "@ionic/eslint-config/recommended"
   },

--- a/packages/storage/.swiftlintrc.js
+++ b/packages/storage/.swiftlintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('../../swiftlint.config.js');

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -64,7 +64,6 @@
     "@capacitor/docgen": "0.3.1",
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
-    "@ionic/swiftlint-config": "2.0.0",
     "eslint": "8.57.0",
     "firebase": "11.2.0",
     "prettier": "3.4.2",
@@ -83,7 +82,6 @@
       "optional": true
     }
   },
-  "swiftlint": "@ionic/swiftlint-config",
   "eslintConfig": {
     "extends": "@ionic/eslint-config/recommended"
   },

--- a/swiftlint.config.js
+++ b/swiftlint.config.js
@@ -1,0 +1,10 @@
+const base = require('@ionic/swiftlint-config');
+
+module.exports = {
+  ...base,
+  excluded: [
+    ...(base.excluded || []).map((p) => p.replace('${PWD}', process.cwd())),
+    `${process.cwd()}/.build`,
+    `${process.cwd()}/example`,
+  ],
+};


### PR DESCRIPTION
`node-swiftlint` writes the `@ionic/swiftlint-config` as JSON to a temp file, but SwiftLint only expands `${PWD}` in YAML configs. This means the exclusion rules were silently broken — swiftlint was scanning all dependency files (`.build/`, `ios/Pods/`, `example/`).

Changes:
- Add root `swiftlint.config.js` that resolves `${PWD}` at JS evaluation time
- Add per-package `.swiftlintrc.js` that delegates to the shared root config
- Move `@ionic/swiftlint-config` from per-package to root devDependencies