### PR TITLE
fix(firestore): Added missing data serialization in the FirebaseFirestoreClientestoreClient.

### DIFF
--- a/.changeset/proud-donuts-mix.md
+++ b/.changeset/proud-donuts-mix.md
@@ -1,5 +1,0 @@
----
-'@capacitor-firebase/firestore': patch
----
-
-Added missing data serialization in the FirebaseFirestoreClientestoreClient.


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] The changes have been tested successfully.
- [X] A changeset has been created (`npm run changeset`).
- [X] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

It fixes the issue with filters that use Timestamp values. The problem was reproducible only on iOS.

### Example
Using any filter with a Timestamp value resulted in empty responses from the getCollection, getCollectionGroup, addCollectionSnapshotListener, and addCollectionGroupSnapshotListener methods.

```
const filterConstraints: QueryFilterConstraint[] = [
          {
            type: 'where',
            fieldPath: 'createdAt',
            opStr: '<',
            value: Timestamp.fromDate(new Date()),
          },
        ]
```
