### PR TITLE
feat(remote-config): add `getAll()` method

### DIFF
--- a/.changeset/remote-config-get-all.md
+++ b/.changeset/remote-config-get-all.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/remote-config': minor
+---
+
+feat: add `getAll()` method

--- a/packages/remote-config/README.md
+++ b/packages/remote-config/README.md
@@ -152,6 +152,7 @@ const removeAllListeners = async () => {
 * [`getBoolean(...)`](#getboolean)
 * [`getNumber(...)`](#getnumber)
 * [`getString(...)`](#getstring)
+* [`getAll()`](#getall)
 * [`getInfo()`](#getinfo)
 * [`setMinimumFetchInterval(...)`](#setminimumfetchinterval)
 * [`setDefaults(...)`](#setdefaults)
@@ -264,6 +265,21 @@ Get the value for the given key as a string.
 **Returns:** <code>Promise&lt;<a href="#getstringresult">GetStringResult</a>&gt;</code>
 
 **Since:** 1.3.0
+
+--------------------
+
+
+### getAll()
+
+```typescript
+getAll() => Promise<GetAllResult>
+```
+
+Get all the values from the Remote Config service.
+
+**Returns:** <code>Promise&lt;<a href="#getallresult">GetAllResult</a>&gt;</code>
+
+**Since:** 8.3.0
 
 --------------------
 
@@ -430,6 +446,21 @@ Remove all listeners for this plugin.
 | ------------ | --------------------------------------------------------- | ----------------------------------------------------------------------------------- | ----- |
 | **`value`**  | <code>string</code>                                       | The value for the given key as a string.                                            | 1.3.0 |
 | **`source`** | <code><a href="#getvaluesource">GetValueSource</a></code> | Indicates at which source this value came from. Only available for Android and iOS. | 1.3.0 |
+
+
+#### GetAllResult
+
+| Prop         | Type                                                                                  | Description              | Since |
+| ------------ | ------------------------------------------------------------------------------------- | ------------------------ | ----- |
+| **`values`** | <code>Record&lt;string, <a href="#getallresultvalue">GetAllResultValue</a>&gt;</code> | The values for all keys. | 8.3.0 |
+
+
+#### GetAllResultValue
+
+| Prop         | Type                                                      | Description                                                                         | Since |
+| ------------ | --------------------------------------------------------- | ----------------------------------------------------------------------------------- | ----- |
+| **`value`**  | <code>string</code>                                       | The value as a string.                                                              | 8.3.0 |
+| **`source`** | <code><a href="#getvaluesource">GetValueSource</a></code> | Indicates at which source this value came from. Only available for Android and iOS. | 8.3.0 |
 
 
 #### GetInfoResult

--- a/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -81,6 +81,10 @@ public class FirebaseRemoteConfig {
         return new GetValueResult<String>(value.asString(), value.getSource());
     }
 
+    public Map<String, FirebaseRemoteConfigValue> getAll() {
+        return getFirebaseRemoteConfigInstance().getAll();
+    }
+
     public GetInfoResult getInfo() {
         FirebaseRemoteConfigInfo info = getFirebaseRemoteConfigInstance().getInfo();
         long lastFetchTime = info.getFetchTimeMillis();

--- a/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
+++ b/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
@@ -6,6 +6,7 @@ import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigValue;
 import io.capawesome.capacitorjs.plugins.firebase.remoteconfig.classes.options.AddConfigUpdateListenerOptions;
 import io.capawesome.capacitorjs.plugins.firebase.remoteconfig.classes.options.RemoveConfigUpdateListenerOptions;
 import io.capawesome.capacitorjs.plugins.firebase.remoteconfig.interfaces.NonEmptyResultCallback;
@@ -151,6 +152,27 @@ public class FirebaseRemoteConfigPlugin extends Plugin {
             JSObject result = new JSObject();
             result.put("value", getValueResult.value);
             result.put("source", getValueResult.source);
+            call.resolve(result);
+        } catch (Exception exception) {
+            Logger.error(TAG, exception.getMessage(), exception);
+            call.reject(exception.getMessage());
+        }
+    }
+
+    @PluginMethod
+    public void getAll(PluginCall call) {
+        try {
+            Map<String, FirebaseRemoteConfigValue> all = implementation.getAll();
+            JSObject values = new JSObject();
+            for (Map.Entry<String, FirebaseRemoteConfigValue> entry : all.entrySet()) {
+                FirebaseRemoteConfigValue value = entry.getValue();
+                JSObject valueObject = new JSObject();
+                valueObject.put("value", value.asString());
+                valueObject.put("source", value.getSource());
+                values.put(entry.getKey(), valueObject);
+            }
+            JSObject result = new JSObject();
+            result.put("values", values);
             call.resolve(result);
         } catch (Exception exception) {
             Logger.error(TAG, exception.getMessage(), exception);

--- a/packages/remote-config/ios/Plugin/FirebaseRemoteConfig.swift
+++ b/packages/remote-config/ios/Plugin/FirebaseRemoteConfig.swift
@@ -56,6 +56,18 @@ import Capacitor
         return RemoteConfig.remoteConfig().configValue(forKey: key)
     }
 
+    @objc public func getAll() -> [String: RemoteConfigValue] {
+        let rc = RemoteConfig.remoteConfig()
+        var keys = Set<String>()
+        keys.formUnion(rc.allKeys(from: .remote))
+        keys.formUnion(rc.allKeys(from: .default))
+        var values: [String: RemoteConfigValue] = [:]
+        for key in keys {
+            values[key] = rc.configValue(forKey: key)
+        }
+        return values
+    }
+
     @objc public func getInfo(completion: @escaping (Double, Int, String?) -> Void) {
         let rc = RemoteConfig.remoteConfig()
 

--- a/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.swift
+++ b/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.swift
@@ -17,6 +17,7 @@ public class FirebaseRemoteConfigPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "getBoolean", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getNumber", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getString", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getAll", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setMinimumFetchInterval", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setDefaults", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setSettings", returnType: CAPPluginReturnPromise),
@@ -102,6 +103,20 @@ public class FirebaseRemoteConfigPlugin: CAPPlugin, CAPBridgedPlugin {
         call.resolve([
             "value": value!.stringValue ?? "",
             "source": FirebaseRemoteConfigHelper.mapRemoteConfigSourceToInt(value!.source)
+        ])
+    }
+
+    @objc func getAll(_ call: CAPPluginCall) {
+        let all = implementation?.getAll() ?? [:]
+        var values: [String: Any] = [:]
+        for (key, value) in all {
+            values[key] = [
+                "value": value.stringValue ?? "",
+                "source": FirebaseRemoteConfigHelper.mapRemoteConfigSourceToInt(value.source)
+            ]
+        }
+        call.resolve([
+            "values": values
         ])
     }
 

--- a/packages/remote-config/src/definitions.ts
+++ b/packages/remote-config/src/definitions.ts
@@ -36,6 +36,12 @@ export interface FirebaseRemoteConfigPlugin {
    */
   getString(options: GetStringOptions): Promise<GetStringResult>;
   /**
+   * Get all the values from the Remote Config service.
+   *
+   * @since 8.3.0
+   */
+  getAll(): Promise<GetAllResult>;
+  /**
    * Get information about the last fetch operation.
    *
    * @since 7.5.0
@@ -194,6 +200,38 @@ export interface GetStringResult {
    * Only available for Android and iOS.
    *
    * @since 1.3.0
+   */
+  source?: GetValueSource;
+}
+
+/**
+ * @since 8.3.0
+ */
+export interface GetAllResult {
+  /**
+   * The values for all keys.
+   *
+   * @since 8.3.0
+   */
+  values: Record<string, GetAllResultValue>;
+}
+
+/**
+ * @since 8.3.0
+ */
+export interface GetAllResultValue {
+  /**
+   * The value as a string.
+   *
+   * @since 8.3.0
+   */
+  value: string;
+  /**
+   * Indicates at which source this value came from.
+   *
+   * Only available for Android and iOS.
+   *
+   * @since 8.3.0
    */
   source?: GetValueSource;
 }

--- a/packages/remote-config/src/web.ts
+++ b/packages/remote-config/src/web.ts
@@ -3,6 +3,7 @@ import {
   activate,
   fetchAndActivate,
   fetchConfig,
+  getAll,
   getBoolean,
   getNumber,
   getRemoteConfig,
@@ -12,6 +13,8 @@ import {
 import type {
   AddConfigUpdateListenerOptionsCallback,
   FirebaseRemoteConfigPlugin,
+  GetAllResult,
+  GetAllResultValue,
   GetBooleanResult,
   GetInfoResult,
   GetNumberResult,
@@ -59,6 +62,16 @@ export class FirebaseRemoteConfigWeb
     const remoteConfig = getRemoteConfig();
     const value = getString(remoteConfig, options.key);
     return { value };
+  }
+
+  public async getAll(): Promise<GetAllResult> {
+    const remoteConfig = getRemoteConfig();
+    const all = getAll(remoteConfig);
+    const values: Record<string, GetAllResultValue> = {};
+    for (const key of Object.keys(all)) {
+      values[key] = { value: all[key].asString() };
+    }
+    return { values };
   }
 
   public async getInfo(): Promise<GetInfoResult> {


### PR DESCRIPTION
## Summary
- Adds `getAll()` to the `@capacitor-firebase/remote-config` plugin, returning every Remote Config key/value pair as strings, with `source` (`Static` / `Default` / `Remote`) on Android and iOS.
- Web uses Firebase JS SDK `getAll()`; Android uses `FirebaseRemoteConfig.getAll()`; iOS unions keys from `.default` and `.remote` sources and reads each via `configValue(forKey:)`.

## Test plan
- [ ] Web: call `FirebaseRemoteConfig.getAll()` after `fetchAndActivate()` and confirm every fetched key is present.
- [ ] Android: call `FirebaseRemoteConfig.getAll()` after `fetchAndActivate()` and confirm values + `source` are correct.
- [ ] iOS: call `FirebaseRemoteConfig.getAll()` after `fetchAndActivate()` and confirm values + `source` are correct, including default keys.

Closes #976