### PR TITLE
feat(remote-config): expose value source on Web

### DIFF
--- a/.changeset/remote-config-source-on-web.md
+++ b/.changeset/remote-config-source-on-web.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/remote-config': minor
+---
+
+feat: expose value `source` on Web for `getBoolean(...)`, `getNumber(...)`, `getString(...)`, and `getAll()`

--- a/packages/remote-config/README.md
+++ b/packages/remote-config/README.md
@@ -419,10 +419,10 @@ Remove all listeners for this plugin.
 
 #### GetBooleanResult
 
-| Prop         | Type                                                      | Description                                                                         | Since |
-| ------------ | --------------------------------------------------------- | ----------------------------------------------------------------------------------- | ----- |
-| **`value`**  | <code>boolean</code>                                      | The value for the given key as a boolean.                                           | 1.3.0 |
-| **`source`** | <code><a href="#getvaluesource">GetValueSource</a></code> | Indicates at which source this value came from. Only available for Android and iOS. | 1.3.0 |
+| Prop         | Type                                                      | Description                                     | Since |
+| ------------ | --------------------------------------------------------- | ----------------------------------------------- | ----- |
+| **`value`**  | <code>boolean</code>                                      | The value for the given key as a boolean.       | 1.3.0 |
+| **`source`** | <code><a href="#getvaluesource">GetValueSource</a></code> | Indicates at which source this value came from. | 1.3.0 |
 
 
 #### GetOptions
@@ -434,18 +434,18 @@ Remove all listeners for this plugin.
 
 #### GetNumberResult
 
-| Prop         | Type                                                      | Description                                                                         | Since |
-| ------------ | --------------------------------------------------------- | ----------------------------------------------------------------------------------- | ----- |
-| **`value`**  | <code>number</code>                                       | The value for the given key as a number.                                            | 1.3.0 |
-| **`source`** | <code><a href="#getvaluesource">GetValueSource</a></code> | Indicates at which source this value came from. Only available for Android and iOS. | 1.3.0 |
+| Prop         | Type                                                      | Description                                     | Since |
+| ------------ | --------------------------------------------------------- | ----------------------------------------------- | ----- |
+| **`value`**  | <code>number</code>                                       | The value for the given key as a number.        | 1.3.0 |
+| **`source`** | <code><a href="#getvaluesource">GetValueSource</a></code> | Indicates at which source this value came from. | 1.3.0 |
 
 
 #### GetStringResult
 
-| Prop         | Type                                                      | Description                                                                         | Since |
-| ------------ | --------------------------------------------------------- | ----------------------------------------------------------------------------------- | ----- |
-| **`value`**  | <code>string</code>                                       | The value for the given key as a string.                                            | 1.3.0 |
-| **`source`** | <code><a href="#getvaluesource">GetValueSource</a></code> | Indicates at which source this value came from. Only available for Android and iOS. | 1.3.0 |
+| Prop         | Type                                                      | Description                                     | Since |
+| ------------ | --------------------------------------------------------- | ----------------------------------------------- | ----- |
+| **`value`**  | <code>string</code>                                       | The value for the given key as a string.        | 1.3.0 |
+| **`source`** | <code><a href="#getvaluesource">GetValueSource</a></code> | Indicates at which source this value came from. | 1.3.0 |
 
 
 #### GetAllResult
@@ -457,10 +457,10 @@ Remove all listeners for this plugin.
 
 #### GetAllResultValue
 
-| Prop         | Type                                                      | Description                                                                         | Since |
-| ------------ | --------------------------------------------------------- | ----------------------------------------------------------------------------------- | ----- |
-| **`value`**  | <code>string</code>                                       | The value as a string.                                                              | 8.3.0 |
-| **`source`** | <code><a href="#getvaluesource">GetValueSource</a></code> | Indicates at which source this value came from. Only available for Android and iOS. | 8.3.0 |
+| Prop         | Type                                                      | Description                                     | Since |
+| ------------ | --------------------------------------------------------- | ----------------------------------------------- | ----- |
+| **`value`**  | <code>string</code>                                       | The value as a string.                          | 8.3.0 |
+| **`source`** | <code><a href="#getvaluesource">GetValueSource</a></code> | Indicates at which source this value came from. | 8.3.0 |
 
 
 #### GetInfoResult

--- a/packages/remote-config/src/definitions.ts
+++ b/packages/remote-config/src/definitions.ts
@@ -159,7 +159,7 @@ export interface GetBooleanResult {
    *
    * @since 1.3.0
    */
-  source: GetValueSource;
+  source?: GetValueSource;
 }
 
 /**
@@ -177,7 +177,7 @@ export interface GetNumberResult {
    *
    * @since 1.3.0
    */
-  source: GetValueSource;
+  source?: GetValueSource;
 }
 
 /**
@@ -195,7 +195,7 @@ export interface GetStringResult {
    *
    * @since 1.3.0
    */
-  source: GetValueSource;
+  source?: GetValueSource;
 }
 
 /**
@@ -225,7 +225,7 @@ export interface GetAllResultValue {
    *
    * @since 8.3.0
    */
-  source: GetValueSource;
+  source?: GetValueSource;
 }
 
 /**

--- a/packages/remote-config/src/definitions.ts
+++ b/packages/remote-config/src/definitions.ts
@@ -157,11 +157,9 @@ export interface GetBooleanResult {
   /**
    * Indicates at which source this value came from.
    *
-   * Only available for Android and iOS.
-   *
    * @since 1.3.0
    */
-  source?: GetValueSource;
+  source: GetValueSource;
 }
 
 /**
@@ -177,11 +175,9 @@ export interface GetNumberResult {
   /**
    * Indicates at which source this value came from.
    *
-   * Only available for Android and iOS.
-   *
    * @since 1.3.0
    */
-  source?: GetValueSource;
+  source: GetValueSource;
 }
 
 /**
@@ -197,11 +193,9 @@ export interface GetStringResult {
   /**
    * Indicates at which source this value came from.
    *
-   * Only available for Android and iOS.
-   *
    * @since 1.3.0
    */
-  source?: GetValueSource;
+  source: GetValueSource;
 }
 
 /**
@@ -229,11 +223,9 @@ export interface GetAllResultValue {
   /**
    * Indicates at which source this value came from.
    *
-   * Only available for Android and iOS.
-   *
    * @since 8.3.0
    */
-  source?: GetValueSource;
+  source: GetValueSource;
 }
 
 /**

--- a/packages/remote-config/src/web.ts
+++ b/packages/remote-config/src/web.ts
@@ -4,11 +4,10 @@ import {
   fetchAndActivate,
   fetchConfig,
   getAll,
-  getBoolean,
-  getNumber,
   getRemoteConfig,
-  getString,
+  getValue,
 } from 'firebase/remote-config';
+import type { Value } from 'firebase/remote-config';
 
 import type {
   AddConfigUpdateListenerOptionsCallback,
@@ -25,7 +24,7 @@ import type {
   SetDefaultsOptions,
   SetSettingsOptions,
 } from './definitions';
-import { LastFetchStatus } from './definitions';
+import { GetValueSource, LastFetchStatus } from './definitions';
 
 export class FirebaseRemoteConfigWeb
   extends WebPlugin
@@ -48,20 +47,29 @@ export class FirebaseRemoteConfigWeb
 
   public async getBoolean(options: GetOptions): Promise<GetBooleanResult> {
     const remoteConfig = getRemoteConfig();
-    const value = getBoolean(remoteConfig, options.key);
-    return { value };
+    const value = getValue(remoteConfig, options.key);
+    return {
+      value: value.asBoolean(),
+      source: this.mapValueSource(value.getSource()),
+    };
   }
 
   public async getNumber(options: GetOptions): Promise<GetNumberResult> {
     const remoteConfig = getRemoteConfig();
-    const value = getNumber(remoteConfig, options.key);
-    return { value };
+    const value = getValue(remoteConfig, options.key);
+    return {
+      value: value.asNumber(),
+      source: this.mapValueSource(value.getSource()),
+    };
   }
 
   public async getString(options: GetOptions): Promise<GetStringResult> {
     const remoteConfig = getRemoteConfig();
-    const value = getString(remoteConfig, options.key);
-    return { value };
+    const value = getValue(remoteConfig, options.key);
+    return {
+      value: value.asString(),
+      source: this.mapValueSource(value.getSource()),
+    };
   }
 
   public async getAll(): Promise<GetAllResult> {
@@ -69,7 +77,11 @@ export class FirebaseRemoteConfigWeb
     const all = getAll(remoteConfig);
     const values: Record<string, GetAllResultValue> = {};
     for (const key of Object.keys(all)) {
-      values[key] = { value: all[key].asString() };
+      const value = all[key];
+      values[key] = {
+        value: value.asString(),
+        source: this.mapValueSource(value.getSource()),
+      };
     }
     return { values };
   }
@@ -125,6 +137,20 @@ export class FirebaseRemoteConfigWeb
     _options: RemoveConfigUpdateListenerOptions,
   ): Promise<void> {
     this.throwUnimplementedError();
+  }
+
+  private mapValueSource(
+    source: ReturnType<Value['getSource']>,
+  ): GetValueSource {
+    switch (source) {
+      case 'default':
+        return GetValueSource.Default;
+      case 'remote':
+        return GetValueSource.Remote;
+      case 'static':
+      default:
+        return GetValueSource.Static;
+    }
   }
 
   private throwUnimplementedError(): never {


### PR DESCRIPTION
## Summary
- Populates `source` in the result of `getBoolean(...)`, `getNumber(...)`, `getString(...)`, and `getAll()` on the Web platform by mapping the Firebase JS SDK `Value.getSource()` (`'static'` / `'default'` / `'remote'`) to the `GetValueSource` enum.
- Makes `source` non-optional in `GetBooleanResult`, `GetNumberResult`, `GetStringResult`, and `GetAllResultValue` — it is now always populated on all three platforms.
- Removes the "Only available for Android and iOS" note from the JSDoc.

## Test plan
- [ ] Web: `getBoolean`/`getNumber`/`getString`/`getAll` after `fetchAndActivate()` — `source` reflects `Remote` for fetched keys, `Default` for `setDefaults` keys, and `Static` for unknown keys.
- [ ] Android: existing behavior unchanged; `source` still populated.
- [ ] iOS: existing behavior unchanged; `source` still populated.

Closes #978