### PR TITLE
fix(firestore): handle `DocumentReference` fields in web deserializer

### DIFF
--- a/.changeset/firestore-web-document-reference.md
+++ b/.changeset/firestore-web-document-reference.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/firestore': patch
+---
+
+fix(firestore): handle `DocumentReference` fields in the web deserializer to prevent `Maximum call stack size exceeded`

--- a/packages/firestore/src/definitions.ts
+++ b/packages/firestore/src/definitions.ts
@@ -930,6 +930,30 @@ export interface FirestoreGeoPoint {
 }
 
 /**
+ * Represents a Firestore DocumentReference as a plain marker object.
+ *
+ * @since 8.3.0
+ */
+export interface FirestoreDocumentReference {
+  /**
+   * @since 8.3.0
+   */
+  __type__: 'documentReference';
+  /**
+   * The document's identifier within its collection.
+   *
+   * @since 8.3.0
+   */
+  id: string;
+  /**
+   * The path of the document.
+   *
+   * @since 8.3.0
+   */
+  path: string;
+}
+
+/**
  * Represents a Firestore server timestamp sentinel as a plain marker object.
  *
  * @since 8.2.0

--- a/packages/firestore/src/web.ts
+++ b/packages/firestore/src/web.ts
@@ -10,6 +10,7 @@ import type {
   Unsubscribe,
 } from 'firebase/firestore';
 import {
+  DocumentReference as FirebaseDocumentReference,
   GeoPoint as FirebaseGeoPoint,
   Timestamp as FirebaseTimestamp,
   addDoc,
@@ -586,6 +587,13 @@ export class FirebaseFirestoreWeb
         longitude: data.longitude,
       };
     }
+    if (data instanceof FirebaseDocumentReference) {
+      return {
+        __type__: 'documentReference',
+        id: data.id,
+        path: data.path,
+      };
+    }
     if (Array.isArray(data)) {
       return data.map(item => this.deserializeData(item));
     }
@@ -642,6 +650,8 @@ export class FirebaseFirestoreWeb
         return new FirebaseTimestamp(marker.seconds, marker.nanoseconds);
       case 'geopoint':
         return new FirebaseGeoPoint(marker.latitude, marker.longitude);
+      case 'documentReference':
+        return doc(getFirestore(), marker.path);
       case 'serverTimestamp':
         return serverTimestamp();
       case 'arrayUnion':


### PR DESCRIPTION
## Summary

- Reading a document containing a `DocumentReference` field on web caused `RangeError: Maximum call stack size exceeded` because `deserializeData` had no branch for `DocumentReference` and fell through to the generic object branch, which recursed into the cyclic `_firestore` getter.
- Adds a dedicated branch in `deserializeData` that returns a `{ __type__: 'documentReference', id, path }` marker, mirroring the existing `Timestamp` / `GeoPoint` handling.
- Adds the symmetric `serializeMarker` case so a deserialized reference can be written back unchanged (round-trip via `doc(getFirestore(), marker.path)`).
- Adds the `FirestoreDocumentReference` marker interface to `definitions.ts`.

## Test plan

- [ ] Read a document containing a `DocumentReference` field on web — no `RangeError` is thrown.
- [ ] Returned data contains `{ __type__: 'documentReference', id, path }` for the reference field.
- [ ] Writing that same marker back via `setDocument` / `updateDocument` / `addDocument` stores it as a real Firestore reference (round-trip).
- [ ] `Timestamp`, `GeoPoint`, and other existing data types still serialize/deserialize correctly.

Close #975