### PR TITLE
feat(firestore): Fully support DocumentReference data types.

### DIFF
--- a/packages/firestore/README.md
+++ b/packages/firestore/README.md
@@ -908,20 +908,22 @@ Execute multiple write operations as a single batch.
 
 #### GetCollectionOptions
 
-| Prop                   | Type                                                                                      | Description                                                                                         | Since |
-| ---------------------- | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ----- |
-| **`reference`**        | <code>string</code>                                                                       | The reference as a string, with path components separated by a forward slash (`/`).                 | 5.2.0 |
-| **`compositeFilter`**  | <code><a href="#querycompositefilterconstraint">QueryCompositeFilterConstraint</a></code> | The filter to apply.                                                                                | 5.2.0 |
-| **`queryConstraints`** | <code>QueryNonFilterConstraint[]</code>                                                   | Narrow or order the set of documents to retrieve, but do not explicitly filter for document fields. | 5.2.0 |
+| Prop                   | Type                                                                                      | Description                                                                                                                                                     | Default             | Since |
+| ---------------------- | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- | ----- |
+| **`reference`**        | <code>string</code>                                                                       | The reference as a string, with path components separated by a forward slash (`/`).                                                                             |                     | 5.2.0 |
+| **`compositeFilter`**  | <code><a href="#querycompositefilterconstraint">QueryCompositeFilterConstraint</a></code> | The filter to apply.                                                                                                                                            |                     | 5.2.0 |
+| **`queryConstraints`** | <code>QueryNonFilterConstraint[]</code>                                                   | Narrow or order the set of documents to retrieve, but do not explicitly filter for document fields.                                                             |                     | 5.2.0 |
+| **`serverTimestamps`** | <code><a href="#servertimestampbehavior">ServerTimestampBehavior</a></code>               | Controls how unresolved server timestamps in pending-write documents are returned. See <a href="#getdocumentoptions">`GetDocumentOptions.serverTimestamps`</a>. | <code>'none'</code> | 8.3.0 |
 
 
 #### GetCollectionGroupOptions
 
-| Prop                   | Type                                                                                      | Description                                                                                         | Since |
-| ---------------------- | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ----- |
-| **`reference`**        | <code>string</code>                                                                       | The reference as a string, with path components separated by a forward slash (`/`).                 | 5.2.0 |
-| **`compositeFilter`**  | <code><a href="#querycompositefilterconstraint">QueryCompositeFilterConstraint</a></code> | The filter to apply.                                                                                | 5.2.0 |
-| **`queryConstraints`** | <code>QueryNonFilterConstraint[]</code>                                                   | Narrow or order the set of documents to retrieve, but do not explicitly filter for document fields. | 5.2.0 |
+| Prop                   | Type                                                                                      | Description                                                                                                                                                     | Default             | Since |
+| ---------------------- | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- | ----- |
+| **`reference`**        | <code>string</code>                                                                       | The reference as a string, with path components separated by a forward slash (`/`).                                                                             |                     | 5.2.0 |
+| **`compositeFilter`**  | <code><a href="#querycompositefilterconstraint">QueryCompositeFilterConstraint</a></code> | The filter to apply.                                                                                                                                            |                     | 5.2.0 |
+| **`queryConstraints`** | <code>QueryNonFilterConstraint[]</code>                                                   | Narrow or order the set of documents to retrieve, but do not explicitly filter for document fields.                                                             |                     | 5.2.0 |
+| **`serverTimestamps`** | <code><a href="#servertimestampbehavior">ServerTimestampBehavior</a></code>               | Controls how unresolved server timestamps in pending-write documents are returned. See <a href="#getdocumentoptions">`GetDocumentOptions.serverTimestamps`</a>. | <code>'none'</code> | 8.3.0 |
 
 
 #### GetCountFromServerResult
@@ -933,16 +935,19 @@ Execute multiple write operations as a single batch.
 
 #### GetCountFromServerOptions
 
-| Prop            | Type                | Description                                                                         | Since |
-| --------------- | ------------------- | ----------------------------------------------------------------------------------- | ----- |
-| **`reference`** | <code>string</code> | The reference as a string, with path components separated by a forward slash (`/`). | 6.4.0 |
+| Prop                   | Type                                                                                      | Description                                                                                                                                                            | Since |
+| ---------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| **`reference`**        | <code>string</code>                                                                       | The reference as a string, with path components separated by a forward slash (`/`).                                                                                    | 6.4.0 |
+| **`compositeFilter`**  | <code><a href="#querycompositefilterconstraint">QueryCompositeFilterConstraint</a></code> | The filter to apply to the count query.                                                                                                                                | 8.3.0 |
+| **`queryConstraints`** | <code>QueryNonFilterConstraint[]</code>                                                   | Narrow the set of documents being counted. Cursor-style constraints such as `limit`, `startAt`, etc. influence the result the same way they would for `getCollection`. | 8.3.0 |
 
 
 #### GetDocumentOptions
 
-| Prop            | Type                | Description                                                                         | Since |
-| --------------- | ------------------- | ----------------------------------------------------------------------------------- | ----- |
-| **`reference`** | <code>string</code> | The reference as a string, with path components separated by a forward slash (`/`). | 5.2.0 |
+| Prop                   | Type                                                                        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | Default             | Since |
+| ---------------------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- | ----- |
+| **`reference`**        | <code>string</code>                                                         | The reference as a string, with path components separated by a forward slash (`/`).                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |                     | 5.2.0 |
+| **`serverTimestamps`** | <code><a href="#servertimestampbehavior">ServerTimestampBehavior</a></code> | Controls how server timestamps that have not yet been set to their final value are returned during a pending write. - `'none'` (default): unresolved server timestamps appear as `null`. - `'estimate'`: unresolved server timestamps return a local estimate based on the device's current clock. This estimate will differ from the final value and cause a snapshot to transition from the estimated value to the resolved value. - `'previous'`: unresolved server timestamps return the previous value, or `null` if there is no previous value. | <code>'none'</code> | 8.3.0 |
 
 
 #### RemoveSnapshotListenerOptions
@@ -1057,6 +1062,11 @@ Execute multiple write operations as a single batch.
 #### AddDocumentSnapshotListenerCallbackEvent
 
 <code><a href="#getdocumentresult">GetDocumentResult</a>&lt;T&gt;</code>
+
+
+#### ServerTimestampBehavior
+
+<code>'estimate' | 'previous' | 'none'</code>
 
 </docgen-api>
 

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestore.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestore.java
@@ -2,13 +2,13 @@ package io.capawesome.capacitorjs.plugins.firebase.firestore;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import com.getcapacitor.PluginCall;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.firestore.AggregateQuery;
 import com.google.firebase.firestore.AggregateQuerySnapshot;
 import com.google.firebase.firestore.AggregateSource;
 import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.Filter;
 import com.google.firebase.firestore.FirebaseFirestoreSettings;
 import com.google.firebase.firestore.ListenerRegistration;
@@ -32,6 +32,7 @@ import io.capawesome.capacitorjs.plugins.firebase.firestore.classes.options.Upda
 import io.capawesome.capacitorjs.plugins.firebase.firestore.classes.options.WriteBatchOperation;
 import io.capawesome.capacitorjs.plugins.firebase.firestore.classes.options.WriteBatchOptions;
 import io.capawesome.capacitorjs.plugins.firebase.firestore.classes.results.AddDocumentResult;
+import io.capawesome.capacitorjs.plugins.firebase.firestore.classes.results.GetCollectionGroupResult;
 import io.capawesome.capacitorjs.plugins.firebase.firestore.classes.results.GetCollectionResult;
 import io.capawesome.capacitorjs.plugins.firebase.firestore.classes.results.GetCountFromServerResult;
 import io.capawesome.capacitorjs.plugins.firebase.firestore.classes.results.GetDocumentResult;
@@ -83,12 +84,15 @@ public class FirebaseFirestore {
 
     public void getDocument(@NonNull GetDocumentOptions options, @NonNull NonEmptyResultCallback callback) {
         String reference = options.getReference();
+        DocumentSnapshot.ServerTimestampBehavior behavior = FirebaseFirestoreHelper.toServerTimestampBehavior(
+            options.getServerTimestampBehavior()
+        );
 
         getFirebaseFirestoreInstance()
             .document(reference)
             .get()
             .addOnSuccessListener(documentSnapshot -> {
-                GetDocumentResult result = new GetDocumentResult(documentSnapshot);
+                GetDocumentResult result = new GetDocumentResult(documentSnapshot, behavior);
                 callback.success(result);
             })
             .addOnFailureListener(exception -> callback.error(exception));
@@ -148,6 +152,9 @@ public class FirebaseFirestore {
         String reference = options.getReference();
         QueryCompositeFilterConstraint compositeFilter = options.getCompositeFilter();
         QueryNonFilterConstraint[] queryConstraints = options.getQueryConstraints();
+        DocumentSnapshot.ServerTimestampBehavior behavior = FirebaseFirestoreHelper.toServerTimestampBehavior(
+            options.getServerTimestampBehavior()
+        );
 
         Query query = getFirebaseFirestoreInstance().collection(reference);
         if (compositeFilter != null) {
@@ -164,7 +171,7 @@ public class FirebaseFirestore {
         query
             .get()
             .addOnSuccessListener(querySnapshot -> {
-                GetCollectionResult result = new GetCollectionResult(querySnapshot);
+                GetCollectionResult result = new GetCollectionResult(querySnapshot, behavior);
                 callback.success(result);
             })
             .addOnFailureListener(exception -> callback.error(exception));
@@ -174,6 +181,9 @@ public class FirebaseFirestore {
         String reference = options.getReference();
         QueryCompositeFilterConstraint compositeFilter = options.getCompositeFilter();
         QueryNonFilterConstraint[] queryConstraints = options.getQueryConstraints();
+        DocumentSnapshot.ServerTimestampBehavior behavior = FirebaseFirestoreHelper.toServerTimestampBehavior(
+            options.getServerTimestampBehavior()
+        );
 
         Query query = getFirebaseFirestoreInstance().collectionGroup(reference);
         if (compositeFilter != null) {
@@ -188,7 +198,7 @@ public class FirebaseFirestore {
         query
             .get()
             .addOnSuccessListener(querySnapshot -> {
-                GetCollectionResult result = new GetCollectionResult(querySnapshot);
+                GetCollectionGroupResult result = new GetCollectionGroupResult(querySnapshot, behavior);
                 callback.success(result);
             })
             .addOnFailureListener(exception -> callback.error(exception));
@@ -248,11 +258,25 @@ public class FirebaseFirestore {
         getFirebaseFirestoreInstance().useEmulator(host, port);
     }
 
-    public void getCountFromServer(@NonNull GetCountFromServerOptions options, @NonNull NonEmptyResultCallback callback) {
+    public void getCountFromServer(@NonNull GetCountFromServerOptions options, @NonNull NonEmptyResultCallback callback) throws Exception {
         String reference = options.getReference();
-        Query query = getFirebaseFirestoreInstance().collection(reference);
-        AggregateQuery countQuery = query.count();
+        QueryCompositeFilterConstraint compositeFilter = options.getCompositeFilter();
+        QueryNonFilterConstraint[] queryConstraints = options.getQueryConstraints();
 
+        Query query = getFirebaseFirestoreInstance().collection(reference);
+        if (compositeFilter != null) {
+            Filter filter = compositeFilter.toFilter();
+            if (filter != null) {
+                query = query.where(filter);
+            }
+        }
+        if (queryConstraints.length > 0) {
+            for (QueryNonFilterConstraint queryConstraint : queryConstraints) {
+                query = queryConstraint.toQuery(query, getFirebaseFirestoreInstance());
+            }
+        }
+
+        AggregateQuery countQuery = query.count();
         countQuery
             .get(AggregateSource.SERVER)
             .addOnCompleteListener(task -> {
@@ -269,6 +293,9 @@ public class FirebaseFirestore {
     public void addDocumentSnapshotListener(@NonNull AddDocumentSnapshotListenerOptions options, @NonNull NonEmptyResultCallback callback) {
         String reference = options.getReference();
         String callbackId = options.getCallbackId();
+        DocumentSnapshot.ServerTimestampBehavior behavior = FirebaseFirestoreHelper.toServerTimestampBehavior(
+            options.getServerTimestampBehavior()
+        );
 
         ListenerRegistration listenerRegistration = getFirebaseFirestoreInstance()
             .document(reference)
@@ -278,7 +305,7 @@ public class FirebaseFirestore {
                     if (exception != null) {
                         callback.error(exception);
                     } else {
-                        GetDocumentResult result = new GetDocumentResult(documentSnapshot);
+                        GetDocumentResult result = new GetDocumentResult(documentSnapshot, behavior);
                         callback.success(result);
                     }
                 }
@@ -294,6 +321,9 @@ public class FirebaseFirestore {
         QueryCompositeFilterConstraint compositeFilter = options.getCompositeFilter();
         QueryNonFilterConstraint[] queryConstraints = options.getQueryConstraints();
         String callbackId = options.getCallbackId();
+        DocumentSnapshot.ServerTimestampBehavior behavior = FirebaseFirestoreHelper.toServerTimestampBehavior(
+            options.getServerTimestampBehavior()
+        );
 
         Query query = getFirebaseFirestoreInstance().collection(reference);
         if (compositeFilter != null) {
@@ -312,7 +342,7 @@ public class FirebaseFirestore {
                 if (exception != null) {
                     callback.error(exception);
                 } else {
-                    GetCollectionResult result = new GetCollectionResult(querySnapshot);
+                    GetCollectionResult result = new GetCollectionResult(querySnapshot, behavior);
                     callback.success(result);
                 }
             }
@@ -328,6 +358,9 @@ public class FirebaseFirestore {
         QueryCompositeFilterConstraint compositeFilter = options.getCompositeFilter();
         QueryNonFilterConstraint[] queryConstraints = options.getQueryConstraints();
         String callbackId = options.getCallbackId();
+        DocumentSnapshot.ServerTimestampBehavior behavior = FirebaseFirestoreHelper.toServerTimestampBehavior(
+            options.getServerTimestampBehavior()
+        );
 
         Query query = getFirebaseFirestoreInstance().collectionGroup(reference);
         if (compositeFilter != null) {
@@ -346,7 +379,7 @@ public class FirebaseFirestore {
                 if (exception != null) {
                     callback.error(exception);
                 } else {
-                    GetCollectionResult result = new GetCollectionResult(querySnapshot);
+                    GetCollectionGroupResult result = new GetCollectionGroupResult(querySnapshot, behavior);
                     callback.success(result);
                 }
             }

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestoreHelper.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestoreHelper.java
@@ -7,8 +7,11 @@ import androidx.annotation.Nullable;
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
 import com.google.firebase.Timestamp;
+import com.google.firebase.firestore.Blob;
+import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FieldValue;
+import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.FirebaseFirestoreException;
 import com.google.firebase.firestore.GeoPoint;
 import io.capawesome.capacitorjs.plugins.firebase.firestore.classes.constraints.QueryCompositeFilterConstraint;
@@ -50,6 +53,10 @@ public class FirebaseFirestoreHelper {
                 value = createJSObjectFromTimestamp((Timestamp) value);
             } else if (value instanceof GeoPoint) {
                 value = createJSObjectFromGeoPoint((GeoPoint) value);
+            } else if (value instanceof DocumentReference) {
+                value = createJSObjectFromDocumentReference((DocumentReference) value);
+            } else if (value instanceof Blob) {
+                value = createJSObjectFromBlob((Blob) value);
             } else if (value instanceof ArrayList) {
                 value = createJSArrayFromArrayList((ArrayList) value);
             } else if (value instanceof Map) {
@@ -61,7 +68,7 @@ public class FirebaseFirestoreHelper {
     }
 
     public static Object createObjectFromJSValue(Object value) throws JSONException {
-        if (value.toString().equals("null")) {
+        if (value == null || value.toString().equals("null")) {
             return null;
         } else if (value instanceof JSONObject) {
             JSONObject jsonObject = (JSONObject) value;
@@ -118,6 +125,26 @@ public class FirebaseFirestoreHelper {
         }
     }
 
+    /**
+     * Translates the JS-side {@code serverTimestamps} option string into the
+     * Android Firestore SDK's {@link DocumentSnapshot.ServerTimestampBehavior}.
+     * Unknown values fall back to {@code NONE} to match the SDK default.
+     */
+    @NonNull
+    public static DocumentSnapshot.ServerTimestampBehavior toServerTimestampBehavior(@Nullable String value) {
+        if (value == null) {
+            return DocumentSnapshot.ServerTimestampBehavior.NONE;
+        }
+        switch (value) {
+            case "estimate":
+                return DocumentSnapshot.ServerTimestampBehavior.ESTIMATE;
+            case "previous":
+                return DocumentSnapshot.ServerTimestampBehavior.PREVIOUS;
+            default:
+                return DocumentSnapshot.ServerTimestampBehavior.NONE;
+        }
+    }
+
     @Nullable
     private static Object createNativeValueFromMarker(@NonNull JSONObject jsonObject) throws JSONException {
         if (!jsonObject.has("__type__")) {
@@ -129,6 +156,15 @@ public class FirebaseFirestoreHelper {
                 return new Timestamp(jsonObject.getLong("seconds"), jsonObject.getInt("nanoseconds"));
             case "geopoint":
                 return new GeoPoint(jsonObject.getDouble("latitude"), jsonObject.getDouble("longitude"));
+            case "documentReference": {
+                String path = jsonObject.getString("path");
+                return FirebaseFirestore.getInstance().document(path);
+            }
+            case "bytes": {
+                String base64 = jsonObject.getString("base64");
+                byte[] decoded = android.util.Base64.decode(base64, android.util.Base64.NO_WRAP);
+                return Blob.fromBytes(decoded);
+            }
             case "serverTimestamp":
                 return FieldValue.serverTimestamp();
             case "arrayUnion": {
@@ -174,12 +210,35 @@ public class FirebaseFirestoreHelper {
         return object;
     }
 
+    @NonNull
+    private static JSObject createJSObjectFromDocumentReference(@NonNull DocumentReference reference) {
+        JSObject object = new JSObject();
+        object.put("__type__", "documentReference");
+        object.put("id", reference.getId());
+        object.put("path", reference.getPath());
+        return object;
+    }
+
+    @NonNull
+    private static JSObject createJSObjectFromBlob(@NonNull Blob blob) {
+        JSObject object = new JSObject();
+        object.put("__type__", "bytes");
+        object.put("base64", android.util.Base64.encodeToString(blob.toBytes(), android.util.Base64.NO_WRAP));
+        return object;
+    }
+
     private static ArrayList<Object> createArrayListFromJSONArray(JSONArray array) throws JSONException {
         ArrayList<Object> arrayList = new ArrayList<>();
         for (int x = 0; x < array.length(); x++) {
             Object value = array.get(x);
             if (value instanceof JSONObject) {
-                value = createHashMapFromJSONObject((JSONObject) value);
+                JSONObject jsonObject = (JSONObject) value;
+                Object nativeValue = createNativeValueFromMarker(jsonObject);
+                if (nativeValue != null) {
+                    value = nativeValue;
+                } else {
+                    value = createHashMapFromJSONObject(jsonObject);
+                }
             } else if (value instanceof JSONArray) {
                 value = createArrayListFromJSONArray((JSONArray) value);
             }
@@ -195,6 +254,12 @@ public class FirebaseFirestoreHelper {
                 value = createJSObjectFromTimestamp((Timestamp) value);
             } else if (value instanceof GeoPoint) {
                 value = createJSObjectFromGeoPoint((GeoPoint) value);
+            } else if (value instanceof DocumentReference) {
+                value = createJSObjectFromDocumentReference((DocumentReference) value);
+            } else if (value instanceof Blob) {
+                value = createJSObjectFromBlob((Blob) value);
+            } else if (value instanceof ArrayList) {
+                value = createJSArrayFromArrayList((ArrayList) value);
             } else if (value instanceof Map) {
                 value = createJSObjectFromMap((Map<String, Object>) value);
             }

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestoreHelper.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestoreHelper.java
@@ -49,7 +49,10 @@ public class FirebaseFirestoreHelper {
         JSObject object = new JSObject();
         for (String key : map.keySet()) {
             Object value = map.get(key);
-            if (value instanceof Timestamp) {
+            JSObject nonFiniteMarker = nonFiniteMarkerIfNeeded(value);
+            if (nonFiniteMarker != null) {
+                value = nonFiniteMarker;
+            } else if (value instanceof Timestamp) {
                 value = createJSObjectFromTimestamp((Timestamp) value);
             } else if (value instanceof GeoPoint) {
                 value = createJSObjectFromGeoPoint((GeoPoint) value);
@@ -165,6 +168,21 @@ public class FirebaseFirestoreHelper {
                 byte[] decoded = android.util.Base64.decode(base64, android.util.Base64.NO_WRAP);
                 return Blob.fromBytes(decoded);
             }
+            case "double": {
+                // Marker carries NaN / Infinity / -Infinity, none of which survive
+                // a JSON round-trip on their own.
+                String v = jsonObject.optString("value", "NaN");
+                switch (v) {
+                    case "NaN":
+                        return Double.NaN;
+                    case "Infinity":
+                        return Double.POSITIVE_INFINITY;
+                    case "-Infinity":
+                        return Double.NEGATIVE_INFINITY;
+                    default:
+                        return Double.NaN;
+                }
+            }
             case "serverTimestamp":
                 return FieldValue.serverTimestamp();
             case "arrayUnion": {
@@ -250,7 +268,10 @@ public class FirebaseFirestoreHelper {
     private static JSArray createJSArrayFromArrayList(ArrayList arrayList) {
         JSArray array = new JSArray();
         for (Object value : arrayList) {
-            if (value instanceof Timestamp) {
+            JSObject nonFiniteMarker = nonFiniteMarkerIfNeeded(value);
+            if (nonFiniteMarker != null) {
+                value = nonFiniteMarker;
+            } else if (value instanceof Timestamp) {
                 value = createJSObjectFromTimestamp((Timestamp) value);
             } else if (value instanceof GeoPoint) {
                 value = createJSObjectFromGeoPoint((GeoPoint) value);
@@ -266,6 +287,37 @@ public class FirebaseFirestoreHelper {
             array.put(value);
         }
         return array;
+    }
+
+    @NonNull
+    private static JSObject createJSObjectFromDouble(double value) {
+        JSObject object = new JSObject();
+        object.put("__type__", "double");
+        if (Double.isNaN(value)) {
+            object.put("value", "NaN");
+        } else if (value == Double.POSITIVE_INFINITY) {
+            object.put("value", "Infinity");
+        } else {
+            object.put("value", "-Infinity");
+        }
+        return object;
+    }
+
+    @Nullable
+    private static JSObject nonFiniteMarkerIfNeeded(@Nullable Object value) {
+        if (value instanceof Double) {
+            double d = (Double) value;
+            if (Double.isNaN(d) || Double.isInfinite(d)) {
+                return createJSObjectFromDouble(d);
+            }
+        }
+        if (value instanceof Float) {
+            float f = (Float) value;
+            if (Float.isNaN(f) || Float.isInfinite(f)) {
+                return createJSObjectFromDouble((double) f);
+            }
+        }
+        return null;
     }
 
     public static JSObject createSnapshotMetadataResult(DocumentSnapshot snapshot) {

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestorePlugin.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestorePlugin.java
@@ -129,8 +129,9 @@ public class FirebaseFirestorePlugin extends Plugin {
                 call.reject(ERROR_REFERENCE_MISSING);
                 return;
             }
+            String serverTimestamps = call.getString("serverTimestamps");
 
-            GetDocumentOptions options = new GetDocumentOptions(reference);
+            GetDocumentOptions options = new GetDocumentOptions(reference, serverTimestamps);
             NonEmptyResultCallback callback = new NonEmptyResultCallback() {
                 @Override
                 public void success(Result result) {
@@ -256,8 +257,9 @@ public class FirebaseFirestorePlugin extends Plugin {
             }
             JSObject compositeFilter = call.getObject("compositeFilter", null);
             JSArray queryConstraints = call.getArray("queryConstraints", null);
+            String serverTimestamps = call.getString("serverTimestamps");
 
-            GetCollectionOptions options = new GetCollectionOptions(reference, compositeFilter, queryConstraints);
+            GetCollectionOptions options = new GetCollectionOptions(reference, compositeFilter, queryConstraints, serverTimestamps);
             NonEmptyResultCallback callback = new NonEmptyResultCallback() {
                 @Override
                 public void success(Result result) {
@@ -288,8 +290,9 @@ public class FirebaseFirestorePlugin extends Plugin {
             }
             JSObject compositeFilter = call.getObject("compositeFilter");
             JSArray queryConstraints = call.getArray("queryConstraints");
+            String serverTimestamps = call.getString("serverTimestamps");
 
-            GetCollectionGroupOptions options = new GetCollectionGroupOptions(reference, compositeFilter, queryConstraints);
+            GetCollectionGroupOptions options = new GetCollectionGroupOptions(reference, compositeFilter, queryConstraints, serverTimestamps);
             NonEmptyResultCallback callback = new NonEmptyResultCallback() {
                 @Override
                 public void success(Result result) {
@@ -430,8 +433,10 @@ public class FirebaseFirestorePlugin extends Plugin {
                 call.reject(ERROR_REFERENCE_MISSING);
                 return;
             }
+            JSObject compositeFilter = call.getObject("compositeFilter", null);
+            JSArray queryConstraints = call.getArray("queryConstraints", null);
 
-            GetCountFromServerOptions options = new GetCountFromServerOptions(reference);
+            GetCountFromServerOptions options = new GetCountFromServerOptions(reference, compositeFilter, queryConstraints);
             NonEmptyResultCallback callback = new NonEmptyResultCallback() {
                 @Override
                 public void success(Result result) {
@@ -463,6 +468,7 @@ public class FirebaseFirestorePlugin extends Plugin {
                 return;
             }
             Boolean includeMetadataChanges = call.getBoolean("includeMetadataChanges");
+            String serverTimestamps = call.getString("serverTimestamps");
             String callbackId = call.getCallbackId();
 
             this.pluginCallMap.put(callbackId, call);
@@ -470,7 +476,8 @@ public class FirebaseFirestorePlugin extends Plugin {
             AddDocumentSnapshotListenerOptions options = new AddDocumentSnapshotListenerOptions(
                 reference,
                 includeMetadataChanges,
-                callbackId
+                callbackId,
+                serverTimestamps
             );
             NonEmptyResultCallback callback = new NonEmptyResultCallback() {
                 @Override
@@ -505,6 +512,7 @@ public class FirebaseFirestorePlugin extends Plugin {
             JSObject compositeFilter = call.getObject("compositeFilter");
             JSArray queryConstraints = call.getArray("queryConstraints");
             Boolean includeMetadataChanges = call.getBoolean("includeMetadataChanges");
+            String serverTimestamps = call.getString("serverTimestamps");
             String callbackId = call.getCallbackId();
 
             this.pluginCallMap.put(callbackId, call);
@@ -514,7 +522,8 @@ public class FirebaseFirestorePlugin extends Plugin {
                 compositeFilter,
                 queryConstraints,
                 includeMetadataChanges,
-                callbackId
+                callbackId,
+                serverTimestamps
             );
             NonEmptyResultCallback callback = new NonEmptyResultCallback() {
                 @Override
@@ -549,6 +558,7 @@ public class FirebaseFirestorePlugin extends Plugin {
             JSObject compositeFilter = call.getObject("compositeFilter");
             JSArray queryConstraints = call.getArray("queryConstraints");
             Boolean includeMetadataChanges = call.getBoolean("includeMetadataChanges");
+            String serverTimestamps = call.getString("serverTimestamps");
             String callbackId = call.getCallbackId();
 
             this.pluginCallMap.put(callbackId, call);
@@ -558,7 +568,8 @@ public class FirebaseFirestorePlugin extends Plugin {
                 compositeFilter,
                 queryConstraints,
                 includeMetadataChanges,
-                callbackId
+                callbackId,
+                serverTimestamps
             );
             NonEmptyResultCallback callback = new NonEmptyResultCallback() {
                 @Override
@@ -590,7 +601,9 @@ public class FirebaseFirestorePlugin extends Plugin {
             }
 
             PluginCall savedCall = this.pluginCallMap.remove(callbackId);
-            savedCall.release(this.bridge);
+            if (savedCall != null) {
+                savedCall.release(this.bridge);
+            }
 
             RemoveSnapshotListenerOptions options = new RemoveSnapshotListenerOptions(callbackId);
             implementation.removeSnapshotListener(options);

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/AddCollectionGroupSnapshotListenerOptions.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/AddCollectionGroupSnapshotListenerOptions.java
@@ -24,18 +24,23 @@ public class AddCollectionGroupSnapshotListenerOptions {
 
     private boolean includeMetadataChanges;
 
+    @Nullable
+    private final String serverTimestampBehavior;
+
     public AddCollectionGroupSnapshotListenerOptions(
         String reference,
         @Nullable JSObject compositeFilter,
         @Nullable JSArray queryConstraints,
         @Nullable Boolean includeMetadataChanges,
-        String callbackId
+        String callbackId,
+        @Nullable String serverTimestampBehavior
     ) throws JSONException {
         this.reference = reference;
         this.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter);
         this.queryConstraints = FirebaseFirestoreHelper.createQueryNonFilterConstraintArrayFromJSArray(queryConstraints);
         this.includeMetadataChanges = includeMetadataChanges == null ? false : includeMetadataChanges;
         this.callbackId = callbackId;
+        this.serverTimestampBehavior = serverTimestampBehavior;
     }
 
     public String getReference() {
@@ -58,5 +63,10 @@ public class AddCollectionGroupSnapshotListenerOptions {
 
     public String getCallbackId() {
         return callbackId;
+    }
+
+    @Nullable
+    public String getServerTimestampBehavior() {
+        return serverTimestampBehavior;
     }
 }

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/AddCollectionSnapshotListenerOptions.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/AddCollectionSnapshotListenerOptions.java
@@ -4,7 +4,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
-import com.getcapacitor.PluginCall;
 import io.capawesome.capacitorjs.plugins.firebase.firestore.FirebaseFirestoreHelper;
 import io.capawesome.capacitorjs.plugins.firebase.firestore.classes.constraints.QueryCompositeFilterConstraint;
 import io.capawesome.capacitorjs.plugins.firebase.firestore.interfaces.QueryNonFilterConstraint;
@@ -25,18 +24,23 @@ public class AddCollectionSnapshotListenerOptions {
 
     private final boolean includeMetadataChanges;
 
+    @Nullable
+    private final String serverTimestampBehavior;
+
     public AddCollectionSnapshotListenerOptions(
         String reference,
         @Nullable JSObject compositeFilter,
         @Nullable JSArray queryConstraints,
         @Nullable Boolean includeMetadataChanges,
-        String callbackId
+        String callbackId,
+        @Nullable String serverTimestampBehavior
     ) throws JSONException {
         this.reference = reference;
         this.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter);
         this.queryConstraints = FirebaseFirestoreHelper.createQueryNonFilterConstraintArrayFromJSArray(queryConstraints);
         this.includeMetadataChanges = includeMetadataChanges == null ? false : includeMetadataChanges;
         this.callbackId = callbackId;
+        this.serverTimestampBehavior = serverTimestampBehavior;
     }
 
     public String getReference() {
@@ -59,5 +63,10 @@ public class AddCollectionSnapshotListenerOptions {
 
     public String getCallbackId() {
         return callbackId;
+    }
+
+    @Nullable
+    public String getServerTimestampBehavior() {
+        return serverTimestampBehavior;
     }
 }

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/AddDocumentSnapshotListenerOptions.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/AddDocumentSnapshotListenerOptions.java
@@ -8,10 +8,19 @@ public class AddDocumentSnapshotListenerOptions {
     private final boolean includeMetadataChanges;
     private String callbackId;
 
-    public AddDocumentSnapshotListenerOptions(String reference, @Nullable Boolean includeMetadataChanges, String callbackId) {
+    @Nullable
+    private final String serverTimestampBehavior;
+
+    public AddDocumentSnapshotListenerOptions(
+        String reference,
+        @Nullable Boolean includeMetadataChanges,
+        String callbackId,
+        @Nullable String serverTimestampBehavior
+    ) {
         this.reference = reference;
         this.includeMetadataChanges = includeMetadataChanges == null ? false : includeMetadataChanges;
         this.callbackId = callbackId;
+        this.serverTimestampBehavior = serverTimestampBehavior;
     }
 
     public String getReference() {
@@ -24,5 +33,10 @@ public class AddDocumentSnapshotListenerOptions {
 
     public String getCallbackId() {
         return callbackId;
+    }
+
+    @Nullable
+    public String getServerTimestampBehavior() {
+        return serverTimestampBehavior;
     }
 }

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/GetCollectionGroupOptions.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/GetCollectionGroupOptions.java
@@ -20,11 +20,19 @@ public class GetCollectionGroupOptions {
     @NonNull
     private QueryNonFilterConstraint[] queryConstraints;
 
-    public GetCollectionGroupOptions(String reference, @Nullable JSObject compositeFilter, @Nullable JSArray queryConstraints)
-        throws JSONException {
+    @Nullable
+    private final String serverTimestampBehavior;
+
+    public GetCollectionGroupOptions(
+        String reference,
+        @Nullable JSObject compositeFilter,
+        @Nullable JSArray queryConstraints,
+        @Nullable String serverTimestampBehavior
+    ) throws JSONException {
         this.reference = reference;
         this.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter);
         this.queryConstraints = FirebaseFirestoreHelper.createQueryNonFilterConstraintArrayFromJSArray(queryConstraints);
+        this.serverTimestampBehavior = serverTimestampBehavior;
     }
 
     @NonNull
@@ -40,5 +48,10 @@ public class GetCollectionGroupOptions {
     @NonNull
     public QueryNonFilterConstraint[] getQueryConstraints() {
         return queryConstraints;
+    }
+
+    @Nullable
+    public String getServerTimestampBehavior() {
+        return serverTimestampBehavior;
     }
 }

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/GetCollectionOptions.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/GetCollectionOptions.java
@@ -20,11 +20,19 @@ public class GetCollectionOptions {
     @NonNull
     private QueryNonFilterConstraint[] queryConstraints;
 
-    public GetCollectionOptions(String reference, @Nullable JSObject compositeFilter, @Nullable JSArray queryConstraints)
-        throws JSONException {
+    @Nullable
+    private final String serverTimestampBehavior;
+
+    public GetCollectionOptions(
+        String reference,
+        @Nullable JSObject compositeFilter,
+        @Nullable JSArray queryConstraints,
+        @Nullable String serverTimestampBehavior
+    ) throws JSONException {
         this.reference = reference;
         this.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter);
         this.queryConstraints = FirebaseFirestoreHelper.createQueryNonFilterConstraintArrayFromJSArray(queryConstraints);
+        this.serverTimestampBehavior = serverTimestampBehavior;
     }
 
     @NonNull
@@ -40,5 +48,10 @@ public class GetCollectionOptions {
     @NonNull
     public QueryNonFilterConstraint[] getQueryConstraints() {
         return queryConstraints;
+    }
+
+    @Nullable
+    public String getServerTimestampBehavior() {
+        return serverTimestampBehavior;
     }
 }

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/GetCountFromServerOptions.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/GetCountFromServerOptions.java
@@ -1,18 +1,47 @@
 package io.capawesome.capacitorjs.plugins.firebase.firestore.classes.options;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.getcapacitor.JSArray;
+import com.getcapacitor.JSObject;
+import io.capawesome.capacitorjs.plugins.firebase.firestore.FirebaseFirestoreHelper;
+import io.capawesome.capacitorjs.plugins.firebase.firestore.classes.constraints.QueryCompositeFilterConstraint;
+import io.capawesome.capacitorjs.plugins.firebase.firestore.interfaces.QueryNonFilterConstraint;
+import org.json.JSONException;
 
 public class GetCountFromServerOptions {
 
     @NonNull
     private final String reference;
 
-    public GetCountFromServerOptions(@NonNull String reference) {
+    @Nullable
+    private final QueryCompositeFilterConstraint compositeFilter;
+
+    @NonNull
+    private final QueryNonFilterConstraint[] queryConstraints;
+
+    public GetCountFromServerOptions(
+        @NonNull String reference,
+        @Nullable JSObject compositeFilter,
+        @Nullable JSArray queryConstraints
+    ) throws JSONException {
         this.reference = reference;
+        this.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter);
+        this.queryConstraints = FirebaseFirestoreHelper.createQueryNonFilterConstraintArrayFromJSArray(queryConstraints);
     }
 
     @NonNull
     public String getReference() {
         return reference;
+    }
+
+    @Nullable
+    public QueryCompositeFilterConstraint getCompositeFilter() {
+        return compositeFilter;
+    }
+
+    @NonNull
+    public QueryNonFilterConstraint[] getQueryConstraints() {
+        return queryConstraints;
     }
 }

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/GetDocumentOptions.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/GetDocumentOptions.java
@@ -1,14 +1,25 @@
 package io.capawesome.capacitorjs.plugins.firebase.firestore.classes.options;
 
+import androidx.annotation.Nullable;
+
 public class GetDocumentOptions {
 
-    private String reference;
+    private final String reference;
 
-    public GetDocumentOptions(String reference) {
+    @Nullable
+    private final String serverTimestampBehavior;
+
+    public GetDocumentOptions(String reference, @Nullable String serverTimestampBehavior) {
         this.reference = reference;
+        this.serverTimestampBehavior = serverTimestampBehavior;
     }
 
     public String getReference() {
         return reference;
+    }
+
+    @Nullable
+    public String getServerTimestampBehavior() {
+        return serverTimestampBehavior;
     }
 }

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/results/GetCollectionGroupResult.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/results/GetCollectionGroupResult.java
@@ -2,6 +2,7 @@ package io.capawesome.capacitorjs.plugins.firebase.firestore.classes.results;
 
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
+import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.QueryDocumentSnapshot;
 import com.google.firebase.firestore.QuerySnapshot;
 import io.capawesome.capacitorjs.plugins.firebase.firestore.FirebaseFirestoreHelper;
@@ -10,17 +11,23 @@ import org.json.JSONObject;
 
 public class GetCollectionGroupResult implements Result {
 
-    private QuerySnapshot querySnapshot;
+    private final QuerySnapshot querySnapshot;
+    private final DocumentSnapshot.ServerTimestampBehavior serverTimestampBehavior;
 
     public GetCollectionGroupResult(QuerySnapshot querySnapshot) {
+        this(querySnapshot, DocumentSnapshot.ServerTimestampBehavior.NONE);
+    }
+
+    public GetCollectionGroupResult(QuerySnapshot querySnapshot, DocumentSnapshot.ServerTimestampBehavior serverTimestampBehavior) {
         this.querySnapshot = querySnapshot;
+        this.serverTimestampBehavior = serverTimestampBehavior;
     }
 
     @Override
     public JSObject toJSObject() {
         JSArray snapshotsResult = new JSArray();
         for (QueryDocumentSnapshot document : querySnapshot) {
-            JSObject snapshotDataResult = FirebaseFirestoreHelper.createJSObjectFromMap(document.getData());
+            JSObject snapshotDataResult = FirebaseFirestoreHelper.createJSObjectFromMap(document.getData(serverTimestampBehavior));
 
             JSObject snapshotResult = new JSObject();
             snapshotResult.put("id", document.getId());

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/results/GetCollectionResult.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/results/GetCollectionResult.java
@@ -2,6 +2,7 @@ package io.capawesome.capacitorjs.plugins.firebase.firestore.classes.results;
 
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
+import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.QueryDocumentSnapshot;
 import com.google.firebase.firestore.QuerySnapshot;
 import io.capawesome.capacitorjs.plugins.firebase.firestore.FirebaseFirestoreHelper;
@@ -10,17 +11,23 @@ import org.json.JSONObject;
 
 public class GetCollectionResult implements Result {
 
-    private QuerySnapshot querySnapshot;
+    private final QuerySnapshot querySnapshot;
+    private final DocumentSnapshot.ServerTimestampBehavior serverTimestampBehavior;
 
     public GetCollectionResult(QuerySnapshot querySnapshot) {
+        this(querySnapshot, DocumentSnapshot.ServerTimestampBehavior.NONE);
+    }
+
+    public GetCollectionResult(QuerySnapshot querySnapshot, DocumentSnapshot.ServerTimestampBehavior serverTimestampBehavior) {
         this.querySnapshot = querySnapshot;
+        this.serverTimestampBehavior = serverTimestampBehavior;
     }
 
     @Override
     public JSObject toJSObject() {
         JSArray snapshotsResult = new JSArray();
         for (QueryDocumentSnapshot document : querySnapshot) {
-            JSObject snapshotDataResult = FirebaseFirestoreHelper.createJSObjectFromMap(document.getData());
+            JSObject snapshotDataResult = FirebaseFirestoreHelper.createJSObjectFromMap(document.getData(serverTimestampBehavior));
 
             JSObject snapshotResult = new JSObject();
             snapshotResult.put("id", document.getId());

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/results/GetDocumentResult.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/results/GetDocumentResult.java
@@ -8,14 +8,20 @@ import org.json.JSONObject;
 
 public class GetDocumentResult implements Result {
 
-    private DocumentSnapshot documentSnapshot;
+    private final DocumentSnapshot documentSnapshot;
+    private final DocumentSnapshot.ServerTimestampBehavior serverTimestampBehavior;
 
     public GetDocumentResult(DocumentSnapshot documentSnapshot) {
+        this(documentSnapshot, DocumentSnapshot.ServerTimestampBehavior.NONE);
+    }
+
+    public GetDocumentResult(DocumentSnapshot documentSnapshot, DocumentSnapshot.ServerTimestampBehavior serverTimestampBehavior) {
         this.documentSnapshot = documentSnapshot;
+        this.serverTimestampBehavior = serverTimestampBehavior;
     }
 
     public JSObject toJSObject() {
-        Object snapshotDataResult = FirebaseFirestoreHelper.createJSObjectFromMap(documentSnapshot.getData());
+        Object snapshotDataResult = FirebaseFirestoreHelper.createJSObjectFromMap(documentSnapshot.getData(serverTimestampBehavior));
 
         JSObject snapshotResult = new JSObject();
         snapshotResult.put("id", documentSnapshot.getId());

--- a/packages/firestore/ios/Plugin/Classes/Options/AddCollectionGroupSnapshotListenerOptions.swift
+++ b/packages/firestore/ios/Plugin/Classes/Options/AddCollectionGroupSnapshotListenerOptions.swift
@@ -7,13 +7,15 @@ import Capacitor
     private var queryConstraints: [QueryNonFilterConstraint]
     private var includeMetadataChanges: Bool
     private var callbackId: String
+    private var serverTimestampBehavior: String?
 
-    init(reference: String, compositeFilter: JSObject?, queryConstraints: [JSObject]?, includeMetadataChanges: Bool, callbackId: String) {
+    init(reference: String, compositeFilter: JSObject?, queryConstraints: [JSObject]?, includeMetadataChanges: Bool, callbackId: String, serverTimestampBehavior: String? = nil) {
         self.reference = reference
         self.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter)
         self.queryConstraints = FirebaseFirestoreHelper.createQueryNonFilterConstraintArrayFromJSArray(queryConstraints)
         self.includeMetadataChanges = includeMetadataChanges
         self.callbackId = callbackId
+        self.serverTimestampBehavior = serverTimestampBehavior
     }
 
     func getReference() -> String {
@@ -34,5 +36,9 @@ import Capacitor
 
     func getCallbackId() -> String {
         return callbackId
+    }
+
+    func getServerTimestampBehavior() -> String? {
+        return serverTimestampBehavior
     }
 }

--- a/packages/firestore/ios/Plugin/Classes/Options/AddCollectionSnapshotListenerOptions.swift
+++ b/packages/firestore/ios/Plugin/Classes/Options/AddCollectionSnapshotListenerOptions.swift
@@ -7,13 +7,15 @@ import Capacitor
     private var queryConstraints: [QueryNonFilterConstraint]
     private var includeMetadataChanges: Bool
     private var callbackId: String
+    private var serverTimestampBehavior: String?
 
-    init(reference: String, compositeFilter: JSObject?, queryConstraints: [JSObject]?, includeMetadataChanges: Bool, callbackId: String) {
+    init(reference: String, compositeFilter: JSObject?, queryConstraints: [JSObject]?, includeMetadataChanges: Bool, callbackId: String, serverTimestampBehavior: String? = nil) {
         self.reference = reference
         self.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter)
         self.queryConstraints = FirebaseFirestoreHelper.createQueryNonFilterConstraintArrayFromJSArray(queryConstraints)
         self.includeMetadataChanges = includeMetadataChanges
         self.callbackId = callbackId
+        self.serverTimestampBehavior = serverTimestampBehavior
     }
 
     func getReference() -> String {
@@ -34,5 +36,9 @@ import Capacitor
 
     func getCallbackId() -> String {
         return callbackId
+    }
+
+    func getServerTimestampBehavior() -> String? {
+        return serverTimestampBehavior
     }
 }

--- a/packages/firestore/ios/Plugin/Classes/Options/AddDocumentSnapshotListenerOptions.swift
+++ b/packages/firestore/ios/Plugin/Classes/Options/AddDocumentSnapshotListenerOptions.swift
@@ -4,11 +4,13 @@ import Foundation
     private var reference: String
     private var includeMetadataChanges: Bool
     private var callbackId: String
+    private var serverTimestampBehavior: String?
 
-    init(reference: String, includeMetadataChanges: Bool, callbackId: String) {
+    init(reference: String, includeMetadataChanges: Bool, callbackId: String, serverTimestampBehavior: String? = nil) {
         self.reference = reference
         self.includeMetadataChanges = includeMetadataChanges
         self.callbackId = callbackId
+        self.serverTimestampBehavior = serverTimestampBehavior
     }
 
     func getReference() -> String {
@@ -21,5 +23,9 @@ import Foundation
 
     func getCallbackId() -> String {
         return callbackId
+    }
+
+    func getServerTimestampBehavior() -> String? {
+        return serverTimestampBehavior
     }
 }

--- a/packages/firestore/ios/Plugin/Classes/Options/GetCollectionGroupOptions.swift
+++ b/packages/firestore/ios/Plugin/Classes/Options/GetCollectionGroupOptions.swift
@@ -5,11 +5,13 @@ import Capacitor
     private var reference: String
     private var compositeFilter: QueryCompositeFilterConstraint?
     private var queryConstraints: [QueryNonFilterConstraint]
+    private var serverTimestampBehavior: String?
 
-    init(reference: String, compositeFilter: JSObject?, queryConstraints: [JSObject]?) {
+    init(reference: String, compositeFilter: JSObject?, queryConstraints: [JSObject]?, serverTimestampBehavior: String? = nil) {
         self.reference = reference
         self.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter)
         self.queryConstraints = FirebaseFirestoreHelper.createQueryNonFilterConstraintArrayFromJSArray(queryConstraints)
+        self.serverTimestampBehavior = serverTimestampBehavior
     }
 
     func getReference() -> String {
@@ -22,5 +24,9 @@ import Capacitor
 
     func getQueryConstraints() -> [QueryNonFilterConstraint] {
         return queryConstraints
+    }
+
+    func getServerTimestampBehavior() -> String? {
+        return serverTimestampBehavior
     }
 }

--- a/packages/firestore/ios/Plugin/Classes/Options/GetCollectionOptions.swift
+++ b/packages/firestore/ios/Plugin/Classes/Options/GetCollectionOptions.swift
@@ -5,11 +5,13 @@ import Capacitor
     private var reference: String
     private var compositeFilter: QueryCompositeFilterConstraint?
     private var queryConstraints: [QueryNonFilterConstraint]
+    private var serverTimestampBehavior: String?
 
-    init(reference: String, compositeFilter: JSObject?, queryConstraints: [JSObject]?) {
+    init(reference: String, compositeFilter: JSObject?, queryConstraints: [JSObject]?, serverTimestampBehavior: String? = nil) {
         self.reference = reference
         self.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter)
         self.queryConstraints = FirebaseFirestoreHelper.createQueryNonFilterConstraintArrayFromJSArray(queryConstraints)
+        self.serverTimestampBehavior = serverTimestampBehavior
     }
 
     func getReference() -> String {
@@ -22,5 +24,9 @@ import Capacitor
 
     func getQueryConstraints() -> [QueryNonFilterConstraint] {
         return queryConstraints
+    }
+
+    func getServerTimestampBehavior() -> String? {
+        return serverTimestampBehavior
     }
 }

--- a/packages/firestore/ios/Plugin/Classes/Options/GetCountFromServerOptions.swift
+++ b/packages/firestore/ios/Plugin/Classes/Options/GetCountFromServerOptions.swift
@@ -1,13 +1,26 @@
 import Foundation
+import Capacitor
 
 @objc public class GetCountFromServerOptions: NSObject {
     private let reference: String
+    private let compositeFilter: QueryCompositeFilterConstraint?
+    private let queryConstraints: [QueryNonFilterConstraint]
 
-    init(reference: String) {
+    init(reference: String, compositeFilter: JSObject?, queryConstraints: [JSObject]?) {
         self.reference = reference
+        self.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter)
+        self.queryConstraints = FirebaseFirestoreHelper.createQueryNonFilterConstraintArrayFromJSArray(queryConstraints)
     }
 
     func getReference() -> String {
         return reference
+    }
+
+    func getCompositeFilter() -> QueryCompositeFilterConstraint? {
+        return compositeFilter
+    }
+
+    func getQueryConstraints() -> [QueryNonFilterConstraint] {
+        return queryConstraints
     }
 }

--- a/packages/firestore/ios/Plugin/Classes/Options/GetDocumentOptions.swift
+++ b/packages/firestore/ios/Plugin/Classes/Options/GetDocumentOptions.swift
@@ -2,12 +2,18 @@ import Foundation
 
 @objc public class GetDocumentOptions: NSObject {
     private var reference: String
+    private var serverTimestampBehavior: String?
 
-    init(reference: String) {
+    init(reference: String, serverTimestampBehavior: String? = nil) {
         self.reference = reference
+        self.serverTimestampBehavior = serverTimestampBehavior
     }
 
     func getReference() -> String {
         return reference
+    }
+
+    func getServerTimestampBehavior() -> String? {
+        return serverTimestampBehavior
     }
 }

--- a/packages/firestore/ios/Plugin/Classes/Results/GetCollectionGroupResult.swift
+++ b/packages/firestore/ios/Plugin/Classes/Results/GetCollectionGroupResult.swift
@@ -4,15 +4,18 @@ import Capacitor
 
 @objc public class GetCollectionGroupResult: NSObject, Result {
     let querySnapshot: QuerySnapshot
+    let serverTimestampBehavior: ServerTimestampBehavior
 
-    init(_ querySnapshot: QuerySnapshot) {
+    init(_ querySnapshot: QuerySnapshot, serverTimestampBehavior: ServerTimestampBehavior = .none) {
         self.querySnapshot = querySnapshot
+        self.serverTimestampBehavior = serverTimestampBehavior
     }
 
     public func toJSObject() -> AnyObject {
         var snapshotsResult = JSArray()
         for documentSnapshot in querySnapshot.documents {
-            let snapshotDataResult = FirebaseFirestoreHelper.createJSObjectFromHashMap(documentSnapshot.data())
+            let rawData = documentSnapshot.data(with: serverTimestampBehavior)
+            let snapshotDataResult = FirebaseFirestoreHelper.createJSObjectFromHashMap(rawData)
 
             var snapshotResult = JSObject()
             snapshotResult["id"] = documentSnapshot.documentID

--- a/packages/firestore/ios/Plugin/Classes/Results/GetCollectionResult.swift
+++ b/packages/firestore/ios/Plugin/Classes/Results/GetCollectionResult.swift
@@ -4,15 +4,18 @@ import Capacitor
 
 @objc public class GetCollectionResult: NSObject, Result {
     let querySnapshot: QuerySnapshot
+    let serverTimestampBehavior: ServerTimestampBehavior
 
-    init(_ querySnapshot: QuerySnapshot) {
+    init(_ querySnapshot: QuerySnapshot, serverTimestampBehavior: ServerTimestampBehavior = .none) {
         self.querySnapshot = querySnapshot
+        self.serverTimestampBehavior = serverTimestampBehavior
     }
 
     public func toJSObject() -> AnyObject {
         var snapshotsResult = JSArray()
         for documentSnapshot in querySnapshot.documents {
-            let snapshotDataResult = FirebaseFirestoreHelper.createJSObjectFromHashMap(documentSnapshot.data())
+            let rawData = documentSnapshot.data(with: serverTimestampBehavior)
+            let snapshotDataResult = FirebaseFirestoreHelper.createJSObjectFromHashMap(rawData)
 
             var snapshotResult = JSObject()
             snapshotResult["id"] = documentSnapshot.documentID

--- a/packages/firestore/ios/Plugin/Classes/Results/GetDocumentResult.swift
+++ b/packages/firestore/ios/Plugin/Classes/Results/GetDocumentResult.swift
@@ -4,13 +4,16 @@ import Capacitor
 
 @objc public class GetDocumentResult: NSObject, Result {
     let documentSnapshot: DocumentSnapshot
+    let serverTimestampBehavior: ServerTimestampBehavior
 
-    init(_ documentSnapshot: DocumentSnapshot) {
+    init(_ documentSnapshot: DocumentSnapshot, serverTimestampBehavior: ServerTimestampBehavior = .none) {
         self.documentSnapshot = documentSnapshot
+        self.serverTimestampBehavior = serverTimestampBehavior
     }
 
     public func toJSObject() -> AnyObject {
-        let snapshotDataResult = FirebaseFirestoreHelper.createJSObjectFromHashMap(documentSnapshot.data())
+        let rawData = documentSnapshot.data(with: serverTimestampBehavior)
+        let snapshotDataResult = FirebaseFirestoreHelper.createJSObjectFromHashMap(rawData)
 
         var snapshotResult = JSObject()
         snapshotResult["id"] = documentSnapshot.documentID

--- a/packages/firestore/ios/Plugin/FirebaseFirestore.swift
+++ b/packages/firestore/ios/Plugin/FirebaseFirestore.swift
@@ -69,12 +69,13 @@ private actor ListenerRegistrationMap {
 
     @objc public func getDocument(_ options: GetDocumentOptions, completion: @escaping (Result?, Error?) -> Void) {
         let reference = options.getReference()
+        let behavior = FirebaseFirestoreHelper.toServerTimestampBehavior(options.getServerTimestampBehavior())
 
         getFirestoreInstance().document(reference).getDocument { documentSnapshot, error in
             if let error = error {
                 completion(nil, error)
             } else {
-                let result = GetDocumentResult(documentSnapshot!)
+                let result = GetDocumentResult(documentSnapshot!, serverTimestampBehavior: behavior)
                 completion(result, nil)
             }
         }
@@ -148,6 +149,7 @@ private actor ListenerRegistrationMap {
         let reference = options.getReference()
         let compositeFilter = options.getCompositeFilter()
         let queryConstraints = options.getQueryConstraints()
+        let behavior = FirebaseFirestoreHelper.toServerTimestampBehavior(options.getServerTimestampBehavior())
 
         Task {
             do {
@@ -165,7 +167,7 @@ private actor ListenerRegistrationMap {
                 }
 
                 let querySnapshot = try await query.getDocuments()
-                let result = GetCollectionResult(querySnapshot)
+                let result = GetCollectionResult(querySnapshot, serverTimestampBehavior: behavior)
                 completion(result, nil)
             } catch {
                 completion(nil, error)
@@ -177,6 +179,7 @@ private actor ListenerRegistrationMap {
         let reference = options.getReference()
         let compositeFilter = options.getCompositeFilter()
         let queryConstraints = options.getQueryConstraints()
+        let behavior = FirebaseFirestoreHelper.toServerTimestampBehavior(options.getServerTimestampBehavior())
 
         Task {
             do {
@@ -194,7 +197,7 @@ private actor ListenerRegistrationMap {
                 }
 
                 let querySnapshot = try await query.getDocuments()
-                let result = GetCollectionResult(querySnapshot)
+                let result = GetCollectionResult(querySnapshot, serverTimestampBehavior: behavior)
                 completion(result, nil)
             } catch {
                 completion(nil, error)
@@ -248,12 +251,25 @@ private actor ListenerRegistrationMap {
 
     @objc public func getCountFromServer(_ options: GetCountFromServerOptions, completion: @escaping (Result?, Error?) -> Void) {
         let reference = options.getReference()
-        let collectionReference = getFirestoreInstance().collection(reference)
-        let countQuery = collectionReference.count
+        let compositeFilter = options.getCompositeFilter()
+        let queryConstraints = options.getQueryConstraints()
 
         Task {
             do {
-                let snapshot = try await countQuery.getAggregation(source: .server)
+                let collectionReference = getFirestoreInstance().collection(reference)
+                var query = collectionReference as Query
+                if let compositeFilter = compositeFilter {
+                    if let filter = compositeFilter.toFilter() {
+                        query = query.whereFilter(filter)
+                    }
+                }
+                if !queryConstraints.isEmpty {
+                    for queryConstraint in queryConstraints {
+                        query = try await queryConstraint.toQuery(query: query, firestore: getFirestoreInstance())
+                    }
+                }
+
+                let snapshot = try await query.count.getAggregation(source: .server)
                 let result = GetCountFromServerResult(snapshot.count.intValue)
                 completion(result, nil)
             } catch {
@@ -266,12 +282,13 @@ private actor ListenerRegistrationMap {
         let reference = options.getReference()
         let includeMetadataChanges = options.getIncludeMetadataChanges()
         let callbackId = options.getCallbackId()
+        let behavior = FirebaseFirestoreHelper.toServerTimestampBehavior(options.getServerTimestampBehavior())
 
         let listenerRegistration = getFirestoreInstance().document(reference).addSnapshotListener(includeMetadataChanges: includeMetadataChanges) { documentSnapshot, error in
             if let error = error {
                 completion(nil, error)
             } else {
-                let result = GetDocumentResult(documentSnapshot!)
+                let result = GetDocumentResult(documentSnapshot!, serverTimestampBehavior: behavior)
                 completion(result, nil)
             }
         }
@@ -286,6 +303,7 @@ private actor ListenerRegistrationMap {
         let queryConstraints = options.getQueryConstraints()
         let includeMetadataChanges = options.getIncludeMetadataChanges()
         let callbackId = options.getCallbackId()
+        let behavior = FirebaseFirestoreHelper.toServerTimestampBehavior(options.getServerTimestampBehavior())
 
         Task {
             do {
@@ -306,7 +324,7 @@ private actor ListenerRegistrationMap {
                     if let error = error {
                         completion(nil, error)
                     } else {
-                        let result = GetCollectionResult(querySnapshot!)
+                        let result = GetCollectionResult(querySnapshot!, serverTimestampBehavior: behavior)
                         completion(result, nil)
                     }
                 }
@@ -323,6 +341,7 @@ private actor ListenerRegistrationMap {
         let queryConstraints = options.getQueryConstraints()
         let includeMetadataChanges = options.getIncludeMetadataChanges()
         let callbackId = options.getCallbackId()
+        let behavior = FirebaseFirestoreHelper.toServerTimestampBehavior(options.getServerTimestampBehavior())
 
         Task {
             do {
@@ -343,7 +362,7 @@ private actor ListenerRegistrationMap {
                     if let error = error {
                         completion(nil, error)
                     } else {
-                        let result = GetCollectionGroupResult(querySnapshot!)
+                        let result = GetCollectionGroupResult(querySnapshot!, serverTimestampBehavior: behavior)
                         completion(result, nil)
                     }
                 }

--- a/packages/firestore/ios/Plugin/FirebaseFirestoreHelper.swift
+++ b/packages/firestore/ios/Plugin/FirebaseFirestoreHelper.swift
@@ -111,6 +111,15 @@ public class FirebaseFirestoreHelper {
             guard let base64 = dict["base64"] as? String,
                   let data = Data(base64Encoded: base64) else { return nil }
             return data
+        case "double":
+            // Marker carries NaN / Infinity / -Infinity, none of which survive
+            // a JSON round-trip on their own.
+            switch dict["value"] as? String {
+            case "NaN": return Double.nan
+            case "Infinity": return Double.infinity
+            case "-Infinity": return -Double.infinity
+            default: return Double.nan
+            }
         case "serverTimestamp":
             return FieldValue.serverTimestamp()
         case "arrayUnion":
@@ -134,9 +143,45 @@ public class FirebaseFirestoreHelper {
         }
     }
 
+    private static func createJSObjectFromDouble(_ value: Double) -> JSObject {
+        var object: JSObject = [:]
+        object["__type__"] = "double"
+        if value.isNaN {
+            object["value"] = "NaN"
+        } else if value == .infinity {
+            object["value"] = "Infinity"
+        } else {
+            object["value"] = "-Infinity"
+        }
+        return object
+    }
+
+    private static func nonFiniteMarkerIfNeeded(_ value: Any) -> JSObject? {
+        if let n = value as? NSNumber {
+            // Distinguish a Double NSNumber from a Bool/Int. CFNumber type code is "d" for double.
+            let typeStr = String(cString: n.objCType)
+            if typeStr == "d" || typeStr == "f" {
+                let d = n.doubleValue
+                if !d.isFinite {
+                    return createJSObjectFromDouble(d)
+                }
+            }
+        }
+        if let d = value as? Double, !d.isFinite {
+            return createJSObjectFromDouble(d)
+        }
+        if let f = value as? Float, !f.isFinite {
+            return createJSObjectFromDouble(Double(f))
+        }
+        return nil
+    }
+
     private static func createJSValue(value: Any?) -> JSValue? {
         guard let value = value else {
             return nil
+        }
+        if let marker = nonFiniteMarkerIfNeeded(value) {
+            return marker as JSValue
         }
         if let timestamp = value as? Timestamp {
             return createJSObjectFromTimestamp(timestamp) as JSValue
@@ -198,6 +243,9 @@ public class FirebaseFirestoreHelper {
 
     private static func createJSArrayFromArray(_ array: [Any]) -> [Any] {
         return array.map { item -> Any in
+            if let marker = nonFiniteMarkerIfNeeded(item) {
+                return marker
+            }
             if let timestamp = item as? Timestamp {
                 return createJSObjectFromTimestamp(timestamp)
             }

--- a/packages/firestore/ios/Plugin/FirebaseFirestoreHelper.swift
+++ b/packages/firestore/ios/Plugin/FirebaseFirestoreHelper.swift
@@ -60,26 +60,41 @@ public class FirebaseFirestoreHelper {
         }
     }
 
-    public static func createNativeValue(_ value: Any) -> Any {
+    /// Translates the JS-side `serverTimestamps` option (`"estimate"` /
+    /// `"previous"` / `"none"` / nil) to the iOS Firestore SDK's
+    /// `ServerTimestampBehavior`. Unknown values fall back to `.none` to match
+    /// the SDK default rather than throw.
+    public static func toServerTimestampBehavior(_ value: String?) -> ServerTimestampBehavior {
+        switch value {
+        case "estimate":
+            return .estimate
+        case "previous":
+            return .previous
+        default:
+            return .none
+        }
+    }
+
+    public static func createNativeValue(_ value: Any, firestore: Firestore? = nil) -> Any {
         if let dict = value as? [String: Any], let type = dict["__type__"] as? String {
-            if let markerValue = createNativeValueFromMarker(type: type, dict: dict) {
+            if let markerValue = createNativeValueFromMarker(type: type, dict: dict, firestore: firestore) {
                 return markerValue
             }
         }
         if let dict = value as? [String: Any] {
             var result: [String: Any] = [:]
             for (key, val) in dict {
-                result[key] = createNativeValue(val)
+                result[key] = createNativeValue(val, firestore: firestore)
             }
             return result
         }
         if let array = value as? [Any] {
-            return array.map { createNativeValue($0) }
+            return array.map { createNativeValue($0, firestore: firestore) }
         }
         return value
     }
 
-    private static func createNativeValueFromMarker(type: String, dict: [String: Any]) -> Any? {
+    private static func createNativeValueFromMarker(type: String, dict: [String: Any], firestore: Firestore?) -> Any? {
         switch type {
         case "timestamp":
             guard let seconds = (dict["seconds"] as? NSNumber)?.int64Value,
@@ -89,13 +104,20 @@ public class FirebaseFirestoreHelper {
             guard let latitude = (dict["latitude"] as? NSNumber)?.doubleValue,
                   let longitude = (dict["longitude"] as? NSNumber)?.doubleValue else { return nil }
             return GeoPoint(latitude: latitude, longitude: longitude)
+        case "documentReference":
+            guard let path = dict["path"] as? String else { return nil }
+            return (firestore ?? Firestore.firestore()).document(path)
+        case "bytes":
+            guard let base64 = dict["base64"] as? String,
+                  let data = Data(base64Encoded: base64) else { return nil }
+            return data
         case "serverTimestamp":
             return FieldValue.serverTimestamp()
         case "arrayUnion":
-            let elements = (dict["elements"] as? [Any] ?? []).map { createNativeValue($0) }
+            let elements = (dict["elements"] as? [Any] ?? []).map { createNativeValue($0, firestore: firestore) }
             return FieldValue.arrayUnion(elements)
         case "arrayRemove":
-            let elements = (dict["elements"] as? [Any] ?? []).map { createNativeValue($0) }
+            let elements = (dict["elements"] as? [Any] ?? []).map { createNativeValue($0, firestore: firestore) }
             return FieldValue.arrayRemove(elements)
         case "delete":
             return FieldValue.delete()
@@ -121,6 +143,12 @@ public class FirebaseFirestoreHelper {
         }
         if let geoPoint = value as? GeoPoint {
             return createJSObjectFromGeoPoint(geoPoint) as JSValue
+        }
+        if let documentReference = value as? DocumentReference {
+            return createJSObjectFromDocumentReference(documentReference) as JSValue
+        }
+        if let data = value as? Data {
+            return createJSObjectFromBytes(data) as JSValue
         }
         if let array = value as? [Any] {
             return createJSArrayFromArray(array) as JSValue
@@ -153,6 +181,21 @@ public class FirebaseFirestoreHelper {
         return object
     }
 
+    private static func createJSObjectFromDocumentReference(_ reference: DocumentReference) -> JSObject {
+        var object: JSObject = [:]
+        object["__type__"] = "documentReference"
+        object["id"] = reference.documentID
+        object["path"] = reference.path
+        return object
+    }
+
+    private static func createJSObjectFromBytes(_ data: Data) -> JSObject {
+        var object: JSObject = [:]
+        object["__type__"] = "bytes"
+        object["base64"] = data.base64EncodedString()
+        return object
+    }
+
     private static func createJSArrayFromArray(_ array: [Any]) -> [Any] {
         return array.map { item -> Any in
             if let timestamp = item as? Timestamp {
@@ -160,6 +203,12 @@ public class FirebaseFirestoreHelper {
             }
             if let geoPoint = item as? GeoPoint {
                 return createJSObjectFromGeoPoint(geoPoint)
+            }
+            if let documentReference = item as? DocumentReference {
+                return createJSObjectFromDocumentReference(documentReference)
+            }
+            if let data = item as? Data {
+                return createJSObjectFromBytes(data)
             }
             if let dict = item as? [String: Any] {
                 return createJSObjectFromHashMap(dict) as Any

--- a/packages/firestore/ios/Plugin/FirebaseFirestorePlugin.swift
+++ b/packages/firestore/ios/Plugin/FirebaseFirestorePlugin.swift
@@ -94,8 +94,9 @@ public class FirebaseFirestorePlugin: CAPPlugin, CAPBridgedPlugin {
             call.reject(errorReferenceMissing)
             return
         }
+        let serverTimestamps = call.getString("serverTimestamps")
 
-        let options = GetDocumentOptions(reference: reference)
+        let options = GetDocumentOptions(reference: reference, serverTimestampBehavior: serverTimestamps)
 
         implementation?.getDocument(options, completion: { result, error in
             if let error = error {
@@ -174,8 +175,9 @@ public class FirebaseFirestorePlugin: CAPPlugin, CAPBridgedPlugin {
         }
         let compositeFilter = call.getObject("compositeFilter")
         let queryConstraints = call.getArray("queryConstraints", JSObject.self)
+        let serverTimestamps = call.getString("serverTimestamps")
 
-        let options = GetCollectionOptions(reference: reference, compositeFilter: compositeFilter, queryConstraints: queryConstraints)
+        let options = GetCollectionOptions(reference: reference, compositeFilter: compositeFilter, queryConstraints: queryConstraints, serverTimestampBehavior: serverTimestamps)
 
         implementation?.getCollection(options, completion: { result, error in
             if let error = error {
@@ -196,8 +198,9 @@ public class FirebaseFirestorePlugin: CAPPlugin, CAPBridgedPlugin {
         }
         let compositeFilter = call.getObject("compositeFilter")
         let queryConstraints = call.getArray("queryConstraints", JSObject.self)
+        let serverTimestamps = call.getString("serverTimestamps")
 
-        let options = GetCollectionGroupOptions(reference: reference, compositeFilter: compositeFilter, queryConstraints: queryConstraints)
+        let options = GetCollectionGroupOptions(reference: reference, compositeFilter: compositeFilter, queryConstraints: queryConstraints, serverTimestampBehavior: serverTimestamps)
 
         implementation?.getCollectionGroup(options, completion: { result, error in
             if let error = error {
@@ -272,8 +275,10 @@ public class FirebaseFirestorePlugin: CAPPlugin, CAPBridgedPlugin {
             call.reject(errorReferenceMissing)
             return
         }
+        let compositeFilter = call.getObject("compositeFilter")
+        let queryConstraints = call.getArray("queryConstraints", JSObject.self)
 
-        let options = GetCountFromServerOptions(reference: reference)
+        let options = GetCountFromServerOptions(reference: reference, compositeFilter: compositeFilter, queryConstraints: queryConstraints)
 
         implementation?.getCountFromServer(options, completion: { result, error in
             if let error = error {
@@ -295,6 +300,7 @@ public class FirebaseFirestorePlugin: CAPPlugin, CAPBridgedPlugin {
             return
         }
         let includeMetadataChanges = call.getBool("includeMetadataChanges", false)
+        let serverTimestamps = call.getString("serverTimestamps")
         guard let callbackId = call.callbackId else {
             call.reject(errorCallbackIdMissing)
             return
@@ -302,7 +308,7 @@ public class FirebaseFirestorePlugin: CAPPlugin, CAPBridgedPlugin {
 
         self.pluginCallMap[callbackId] = call
 
-        let options = AddDocumentSnapshotListenerOptions(reference: reference, includeMetadataChanges: includeMetadataChanges, callbackId: callbackId)
+        let options = AddDocumentSnapshotListenerOptions(reference: reference, includeMetadataChanges: includeMetadataChanges, callbackId: callbackId, serverTimestampBehavior: serverTimestamps)
 
         implementation?.addDocumentSnapshotListener(options, completion: { result, error in
             if let error = error {
@@ -326,6 +332,7 @@ public class FirebaseFirestorePlugin: CAPPlugin, CAPBridgedPlugin {
         let compositeFilter = call.getObject("compositeFilter")
         let queryConstraints = call.getArray("queryConstraints", JSObject.self)
         let includeMetadataChanges = call.getBool("includeMetadataChanges", false)
+        let serverTimestamps = call.getString("serverTimestamps")
         guard let callbackId = call.callbackId else {
             call.reject(errorCallbackIdMissing)
             return
@@ -333,7 +340,7 @@ public class FirebaseFirestorePlugin: CAPPlugin, CAPBridgedPlugin {
 
         self.pluginCallMap[callbackId] = call
 
-        let options = AddCollectionSnapshotListenerOptions(reference: reference, compositeFilter: compositeFilter, queryConstraints: queryConstraints, includeMetadataChanges: includeMetadataChanges, callbackId: callbackId)
+        let options = AddCollectionSnapshotListenerOptions(reference: reference, compositeFilter: compositeFilter, queryConstraints: queryConstraints, includeMetadataChanges: includeMetadataChanges, callbackId: callbackId, serverTimestampBehavior: serverTimestamps)
 
         do {
             implementation?.addCollectionSnapshotListener(options, completion: { result, error in
@@ -362,6 +369,7 @@ public class FirebaseFirestorePlugin: CAPPlugin, CAPBridgedPlugin {
         let compositeFilter = call.getObject("compositeFilter")
         let queryConstraints = call.getArray("queryConstraints", JSObject.self)
         let includeMetadataChanges = call.getBool("includeMetadataChanges", false)
+        let serverTimestamps = call.getString("serverTimestamps")
         guard let callbackId = call.callbackId else {
             call.reject(errorCallbackIdMissing)
             return
@@ -369,7 +377,7 @@ public class FirebaseFirestorePlugin: CAPPlugin, CAPBridgedPlugin {
 
         self.pluginCallMap[callbackId] = call
 
-        let options = AddCollectionGroupSnapshotListenerOptions(reference: reference, compositeFilter: compositeFilter, queryConstraints: queryConstraints, includeMetadataChanges: includeMetadataChanges, callbackId: callbackId)
+        let options = AddCollectionGroupSnapshotListenerOptions(reference: reference, compositeFilter: compositeFilter, queryConstraints: queryConstraints, includeMetadataChanges: includeMetadataChanges, callbackId: callbackId, serverTimestampBehavior: serverTimestamps)
 
         do {
             implementation?.addCollectionGroupSnapshotListener(options, completion: { result, error in

--- a/packages/firestore/src/definitions.ts
+++ b/packages/firestore/src/definitions.ts
@@ -235,7 +235,28 @@ export interface GetDocumentOptions {
    * @since 5.2.0
    */
   reference: string;
+  /**
+   * Controls how server timestamps that have not yet been set to their final
+   * value are returned during a pending write.
+   *
+   * - `'none'` (default): unresolved server timestamps appear as `null`.
+   * - `'estimate'`: unresolved server timestamps return a local estimate based
+   *   on the device's current clock. This estimate will differ from the final
+   *   value and cause a snapshot to transition from the estimated value to the
+   *   resolved value.
+   * - `'previous'`: unresolved server timestamps return the previous value, or
+   *   `null` if there is no previous value.
+   *
+   * @since 8.3.0
+   * @default 'none'
+   */
+  serverTimestamps?: ServerTimestampBehavior;
 }
+
+/**
+ * @since 8.3.0
+ */
+export type ServerTimestampBehavior = 'estimate' | 'previous' | 'none';
 
 /**
  * @since 5.2.0
@@ -357,6 +378,14 @@ export interface GetCollectionOptions {
    * @since 5.2.0
    */
   queryConstraints?: QueryNonFilterConstraint[];
+  /**
+   * Controls how unresolved server timestamps in pending-write documents are
+   * returned. See `GetDocumentOptions.serverTimestamps`.
+   *
+   * @since 8.3.0
+   * @default 'none'
+   */
+  serverTimestamps?: ServerTimestampBehavior;
 }
 
 /**
@@ -393,6 +422,14 @@ export interface GetCollectionGroupOptions {
    * @since 5.2.0
    */
   queryConstraints?: QueryNonFilterConstraint[];
+  /**
+   * Controls how unresolved server timestamps in pending-write documents are
+   * returned. See `GetDocumentOptions.serverTimestamps`.
+   *
+   * @since 8.3.0
+   * @default 'none'
+   */
+  serverTimestamps?: ServerTimestampBehavior;
 }
 
 /**
@@ -452,6 +489,14 @@ export interface SnapshotListenerOptions {
    * @default "default"
    */
   readonly source?: 'default' | 'cache';
+  /**
+   * Controls how unresolved server timestamps in pending-write documents are
+   * returned in each snapshot emission. See `GetDocumentOptions.serverTimestamps`.
+   *
+   * @since 8.3.0
+   * @default 'none'
+   */
+  readonly serverTimestamps?: ServerTimestampBehavior;
 }
 
 /**
@@ -583,6 +628,20 @@ export interface GetCountFromServerOptions {
    * @since 6.4.0
    */
   reference: string;
+  /**
+   * The filter to apply to the count query.
+   *
+   * @since 8.3.0
+   */
+  compositeFilter?: QueryCompositeFilterConstraint;
+  /**
+   * Narrow the set of documents being counted. Cursor-style constraints such as
+   * `limit`, `startAt`, etc. influence the result the same way they would for
+   * `getCollection`.
+   *
+   * @since 8.3.0
+   */
+  queryConstraints?: QueryNonFilterConstraint[];
 }
 
 /**
@@ -1007,6 +1066,26 @@ export interface FirestoreDelete {
    * @since 8.2.0
    */
   __type__: 'delete';
+}
+
+/**
+ * Represents a Firestore Bytes (Blob) value as a plain marker object. The
+ * underlying bytes are encoded as a base64 string for transport across the
+ * Capacitor bridge.
+ *
+ * @since 8.3.0
+ */
+export interface FirestoreBytes {
+  /**
+   * @since 8.3.0
+   */
+  __type__: 'bytes';
+  /**
+   * The bytes encoded as a base64 string.
+   *
+   * @since 8.3.0
+   */
+  base64: string;
 }
 
 /**

--- a/packages/firestore/src/definitions.ts
+++ b/packages/firestore/src/definitions.ts
@@ -1089,6 +1089,27 @@ export interface FirestoreBytes {
 }
 
 /**
+ * Represents a non-finite IEEE 754 double (`NaN`, `Infinity`, `-Infinity`) as a
+ * plain marker object. JSON cannot transport these values directly, so the
+ * Capacitor bridge serializes them via this marker.
+ *
+ * @since 8.3.0
+ */
+export interface FirestoreDouble {
+  /**
+   * @since 8.3.0
+   */
+  __type__: 'double';
+  /**
+   * The non-finite value as a string. One of `"NaN"`, `"Infinity"`, or
+   * `"-Infinity"` (matching `Number.prototype.toString` output).
+   *
+   * @since 8.3.0
+   */
+  value: 'NaN' | 'Infinity' | '-Infinity';
+}
+
+/**
  * Represents a Firestore increment operation as a plain marker object.
  *
  * @since 8.2.0

--- a/packages/firestore/src/utils.ts
+++ b/packages/firestore/src/utils.ts
@@ -13,6 +13,12 @@ export function serializeData(data: any): any {
   ) {
     return data.toJSON();
   }
+  // JSON cannot transport non-finite IEEE 754 doubles; carry them across the
+  // Capacitor bridge as `{ __type__: "double", value: "NaN" | "Infinity" |
+  // "-Infinity" }` and let the platform layer rebuild the primitive.
+  if (typeof data === 'number' && !Number.isFinite(data)) {
+    return { __type__: 'double', value: serializeNonFiniteValue(data) };
+  }
   if (Array.isArray(data)) {
     return data.map(item => serializeData(item));
   }
@@ -40,6 +46,9 @@ export function deserializeData(data: any): any {
     if (data.__type__ === 'geopoint') {
       return new GeoPoint(data.latitude, data.longitude);
     }
+    if (data.__type__ === 'double') {
+      return deserializeNonFiniteValue(data.value);
+    }
     const result: Record<string, any> = {};
     for (const key of Object.keys(data)) {
       result[key] = deserializeData(data[key]);
@@ -47,4 +56,20 @@ export function deserializeData(data: any): any {
     return result;
   }
   return data;
+}
+
+export function serializeNonFiniteValue(
+  n: number,
+): 'NaN' | 'Infinity' | '-Infinity' {
+  if (Number.isNaN(n)) return 'NaN';
+  return n > 0 ? 'Infinity' : '-Infinity';
+}
+
+export function deserializeNonFiniteValue(value: unknown): number {
+  if (value === 'NaN') return Number.NaN;
+  if (value === 'Infinity') return Number.POSITIVE_INFINITY;
+  if (value === '-Infinity') return Number.NEGATIVE_INFINITY;
+  // Unknown — fall back to NaN rather than throwing so a single bad payload
+  // doesn't tear down the listener.
+  return Number.NaN;
 }

--- a/packages/firestore/src/web.ts
+++ b/packages/firestore/src/web.ts
@@ -94,6 +94,7 @@ import type {
 import { FieldValue } from './field-value';
 import { GeoPoint } from './geopoint';
 import { Timestamp } from './timestamp';
+import { deserializeNonFiniteValue, serializeNonFiniteValue } from './utils';
 
 export class FirebaseFirestoreWeb
   extends WebPlugin
@@ -658,6 +659,12 @@ export class FirebaseFirestoreWeb
         base64: data.toBase64(),
       };
     }
+    if (typeof data === 'number' && !Number.isFinite(data)) {
+      return {
+        __type__: 'double',
+        value: serializeNonFiniteValue(data),
+      };
+    }
     if (typeof data !== 'object') {
       return data;
     }
@@ -764,6 +771,8 @@ export class FirebaseFirestoreWeb
         return doc(getFirestore(), marker.path);
       case 'bytes':
         return FirebaseBytes.fromBase64String(marker.base64);
+      case 'double':
+        return deserializeNonFiniteValue(marker.value);
       case 'serverTimestamp':
         return serverTimestamp();
       case 'arrayUnion':

--- a/packages/firestore/src/web.ts
+++ b/packages/firestore/src/web.ts
@@ -1,15 +1,18 @@
 import { WebPlugin } from '@capacitor/core';
 import { getApp } from 'firebase/app';
 import type {
+  DocumentSnapshot as FirebaseDocumentSnapshot,
   QueryCompositeFilterConstraint as FirebaseQueryCompositeFilterConstraint,
   QueryConstraint as FirebaseQueryConstraint,
   QueryFieldFilterConstraint as FirebaseQueryFieldFilterConstraint,
   QueryFilterConstraint as FirebaseQueryFilterConstraint,
   QueryNonFilterConstraint as FirebaseQueryNonFilterConstraint,
   Query,
+  SnapshotOptions,
   Unsubscribe,
 } from 'firebase/firestore';
 import {
+  Bytes as FirebaseBytes,
   DocumentReference as FirebaseDocumentReference,
   GeoPoint as FirebaseGeoPoint,
   Timestamp as FirebaseTimestamp,
@@ -82,6 +85,7 @@ import type {
   QueryFilterConstraint,
   QueryNonFilterConstraint,
   RemoveSnapshotListenerOptions,
+  ServerTimestampBehavior,
   SetDocumentOptions,
   UpdateDocumentOptions,
   UseEmulatorOptions,
@@ -96,6 +100,15 @@ export class FirebaseFirestoreWeb
   implements FirebaseFirestorePlugin
 {
   private readonly unsubscribesMap: Map<string, Unsubscribe> = new Map();
+  /**
+   * Monotonic counter used to generate unique listener IDs.
+   */
+  private listenerIdCounter = 0;
+
+  private nextListenerId(): string {
+    this.listenerIdCounter += 1;
+    return this.listenerIdCounter.toString();
+  }
 
   public async addCollectionGroupSnapshotListener<
     T extends DocumentData = DocumentData,
@@ -107,6 +120,7 @@ export class FirebaseFirestoreWeb
       options,
       'collectionGroup',
     );
+    const snapshotOptions = this.buildSnapshotOptions(options.serverTimestamps);
     const unsubscribe = onSnapshot(
       collectionQuery,
       {
@@ -118,7 +132,9 @@ export class FirebaseFirestoreWeb
           snapshots: snapshot.docs.map(documentSnapshot => ({
             id: documentSnapshot.id,
             path: documentSnapshot.ref.path,
-            data: this.deserializeData(documentSnapshot.data()) as T,
+            data: this.deserializeData(
+              this.readSnapshotData(documentSnapshot, snapshotOptions),
+            ) as T,
             metadata: {
               hasPendingWrites: documentSnapshot.metadata.hasPendingWrites,
               fromCache: documentSnapshot.metadata.fromCache,
@@ -129,7 +145,7 @@ export class FirebaseFirestoreWeb
       },
       error => callback(null, error),
     );
-    const id = Date.now().toString();
+    const id = this.nextListenerId();
     this.unsubscribesMap.set(id, unsubscribe);
     return id;
   }
@@ -144,6 +160,7 @@ export class FirebaseFirestoreWeb
       options,
       'collection',
     );
+    const snapshotOptions = this.buildSnapshotOptions(options.serverTimestamps);
     const unsubscribe = onSnapshot(
       collectionQuery,
       {
@@ -155,7 +172,9 @@ export class FirebaseFirestoreWeb
           snapshots: snapshot.docs.map(documentSnapshot => ({
             id: documentSnapshot.id,
             path: documentSnapshot.ref.path,
-            data: this.deserializeData(documentSnapshot.data()) as T,
+            data: this.deserializeData(
+              this.readSnapshotData(documentSnapshot, snapshotOptions),
+            ) as T,
             metadata: {
               hasPendingWrites: documentSnapshot.metadata.hasPendingWrites,
               fromCache: documentSnapshot.metadata.fromCache,
@@ -166,7 +185,7 @@ export class FirebaseFirestoreWeb
       },
       error => callback(null, error),
     );
-    const id = Date.now().toString();
+    const id = this.nextListenerId();
     this.unsubscribesMap.set(id, unsubscribe);
     return id;
   }
@@ -195,6 +214,7 @@ export class FirebaseFirestoreWeb
     callback: AddDocumentSnapshotListenerCallback<T>,
   ): Promise<string> {
     const firestore = getFirestore();
+    const snapshotOptions = this.buildSnapshotOptions(options.serverTimestamps);
     const unsubscribe = onSnapshot(
       doc(firestore, options.reference),
       {
@@ -202,7 +222,7 @@ export class FirebaseFirestoreWeb
         source: options.source,
       },
       snapshot => {
-        const data = snapshot.data();
+        const data = this.readSnapshotData(snapshot, snapshotOptions);
         const event: AddDocumentSnapshotListenerCallbackEvent<T> = {
           snapshot: {
             id: snapshot.id,
@@ -220,7 +240,7 @@ export class FirebaseFirestoreWeb
       },
       error => callback(null, error),
     );
-    const id = Date.now().toString();
+    const id = this.nextListenerId();
     this.unsubscribesMap.set(id, unsubscribe);
     return id;
   }
@@ -274,11 +294,14 @@ export class FirebaseFirestoreWeb
       'collection',
     );
     const collectionSnapshot = await getDocs(collectionQuery);
+    const snapshotOptions = this.buildSnapshotOptions(options.serverTimestamps);
     return {
       snapshots: collectionSnapshot.docs.map(documentSnapshot => ({
         id: documentSnapshot.id,
         path: documentSnapshot.ref.path,
-        data: this.deserializeData(documentSnapshot.data()) as T,
+        data: this.deserializeData(
+          this.readSnapshotData(documentSnapshot, snapshotOptions),
+        ) as T,
         metadata: {
           hasPendingWrites: documentSnapshot.metadata.hasPendingWrites,
           fromCache: documentSnapshot.metadata.fromCache,
@@ -295,11 +318,14 @@ export class FirebaseFirestoreWeb
       'collectionGroup',
     );
     const collectionSnapshot = await getDocs(collectionQuery);
+    const snapshotOptions = this.buildSnapshotOptions(options.serverTimestamps);
     return {
       snapshots: collectionSnapshot.docs.map(documentSnapshot => ({
         id: documentSnapshot.id,
         path: documentSnapshot.ref.path,
-        data: this.deserializeData(documentSnapshot.data()) as T,
+        data: this.deserializeData(
+          this.readSnapshotData(documentSnapshot, snapshotOptions),
+        ) as T,
         metadata: {
           hasPendingWrites: documentSnapshot.metadata.hasPendingWrites,
           fromCache: documentSnapshot.metadata.fromCache,
@@ -311,10 +337,24 @@ export class FirebaseFirestoreWeb
   public async getCountFromServer(
     options: GetCountFromServerOptions,
   ): Promise<GetCountFromServerResult> {
-    const firestore = getFirestore();
-    const { reference } = options;
-    const coll = collection(firestore, reference);
-    const snapshot = await getCountFromServer(coll);
+    // Accept the same `compositeFilter`/`queryConstraints` shape as
+    // `getCollection`, so callers can count a filtered query rather than only
+    // an entire collection.
+    const hasQuery =
+      options.compositeFilter != null ||
+      (options.queryConstraints != null &&
+        options.queryConstraints.length > 0);
+    const countQuery = hasQuery
+      ? await this.buildCollectionQuery(
+          {
+            reference: options.reference,
+            compositeFilter: options.compositeFilter,
+            queryConstraints: options.queryConstraints,
+          },
+          'collection',
+        )
+      : collection(getFirestore(), options.reference);
+    const snapshot = await getCountFromServer(countQuery);
     return { count: snapshot.data().count };
   }
 
@@ -324,7 +364,11 @@ export class FirebaseFirestoreWeb
     const firestore = getFirestore();
     const { reference } = options;
     const documentSnapshot = await getDoc(doc(firestore, reference));
-    const documentSnapshotData = documentSnapshot.data();
+    const snapshotOptions = this.buildSnapshotOptions(options.serverTimestamps);
+    const documentSnapshotData = this.readSnapshotData(
+      documentSnapshot,
+      snapshotOptions,
+    );
     return {
       snapshot: {
         id: documentSnapshot.id,
@@ -569,7 +613,21 @@ export class FirebaseFirestoreWeb
     return firebaseQueryNonFilterConstraints;
   }
 
-  private deserializeData(data: any): any {
+  /**
+   * Converts JS SDK class instances inside a snapshot's data into the plain
+   * `{ __type__: ... }` marker objects callers consume. A `WeakSet` cycle
+   * guard prevents the recursive walk from following self-referential
+   * properties that the JS SDK builds on some classes (notably
+   * `DocumentReference._firestore` → `... → documentReference`), which would
+   * otherwise stack-overflow when a document contains a DocumentReference
+   * field.
+   *
+   * Each known class (`Timestamp`, `GeoPoint`, `DocumentReference`, `Bytes`)
+   * is checked before the generic object walk. Unknown class instances are
+   * preserved unchanged — falling through to the object walk would also visit
+   * their internal fields and is rarely what callers want.
+   */
+  private deserializeData(data: any, seen: WeakSet<object> = new WeakSet()): any {
     if (data === null || data === undefined) {
       return data;
     }
@@ -594,42 +652,94 @@ export class FirebaseFirestoreWeb
         path: data.path,
       };
     }
+    if (data instanceof FirebaseBytes) {
+      return {
+        __type__: 'bytes',
+        base64: data.toBase64(),
+      };
+    }
+    if (typeof data !== 'object') {
+      return data;
+    }
+    if (seen.has(data)) {
+      return null;
+    }
+    seen.add(data);
     if (Array.isArray(data)) {
-      return data.map(item => this.deserializeData(item));
+      return data.map(item => this.deserializeData(item, seen));
     }
-    if (typeof data === 'object') {
-      const result: Record<string, any> = {};
-      for (const key of Object.keys(data)) {
-        result[key] = this.deserializeData(data[key]);
-      }
-      return result;
+    // Only walk plain objects. Class instances we don't recognize (e.g. an
+    // internal JS SDK type that leaked through) are preserved as-is rather
+    // than having their private fields traversed.
+    const proto = Object.getPrototypeOf(data);
+    if (proto !== Object.prototype && proto !== null) {
+      return data;
     }
-    return data;
+    const result: Record<string, any> = {};
+    for (const key of Object.keys(data)) {
+      result[key] = this.deserializeData(data[key], seen);
+    }
+    return result;
   }
 
-  private serializeData(data: any): any {
+  /**
+   * Converts caller-supplied data into the JS SDK shape `setDoc`/`updateDoc`
+   * expect. Known JS SDK class instances are handled explicitly so the
+   * generic object walk never tries to recurse into the cyclic internals
+   * (`_firestore`, `_query`, ...) of types like `DocumentReference`. `Date`
+   * values are reshaped into the plugin's `timestamp` marker because the
+   * Capacitor bridge would otherwise serialize them as empty objects.
+   */
+  private serializeData(data: any, seen: WeakSet<object> = new WeakSet()): any {
+    if (data === null || data === undefined) {
+      return data;
+    }
     if (data instanceof Timestamp) {
       return new FirebaseTimestamp(data.seconds, data.nanoseconds);
+    }
+    if (data instanceof FirebaseTimestamp) {
+      return data;
+    }
+    if (data instanceof Date) {
+      return FirebaseTimestamp.fromDate(data);
     }
     if (data instanceof GeoPoint) {
       return new FirebaseGeoPoint(data.latitude, data.longitude);
     }
+    if (data instanceof FirebaseGeoPoint) {
+      return data;
+    }
+    if (data instanceof FirebaseDocumentReference) {
+      return data;
+    }
+    if (data instanceof FirebaseBytes) {
+      return data;
+    }
     if (data instanceof FieldValue) {
       return this.serializeFieldValue(data.toJSON());
     }
-    if (data === null || data === undefined) {
-      return data;
-    }
     if (Array.isArray(data)) {
-      return data.map(item => this.serializeData(item));
+      if (seen.has(data)) return null;
+      seen.add(data);
+      return data.map(item => this.serializeData(item, seen));
     }
     if (typeof data === 'object') {
       if (data.__type__) {
         return this.serializeMarker(data);
       }
+      if (seen.has(data)) return null;
+      seen.add(data);
+      const proto = Object.getPrototypeOf(data);
+      if (proto !== Object.prototype && proto !== null) {
+        // Unknown class instance — pass through unchanged so the JS SDK can
+        // either accept it or report a clear validation error. Walking its
+        // internals usually causes a stack overflow or produces a malformed
+        // payload.
+        return data;
+      }
       const result: Record<string, any> = {};
       for (const key of Object.keys(data)) {
-        result[key] = this.serializeData(data[key]);
+        result[key] = this.serializeData(data[key], seen);
       }
       return result;
     }
@@ -652,6 +762,8 @@ export class FirebaseFirestoreWeb
         return new FirebaseGeoPoint(marker.latitude, marker.longitude);
       case 'documentReference':
         return doc(getFirestore(), marker.path);
+      case 'bytes':
+        return FirebaseBytes.fromBase64String(marker.base64);
       case 'serverTimestamp':
         return serverTimestamp();
       case 'arrayUnion':
@@ -669,5 +781,28 @@ export class FirebaseFirestoreWeb
       default:
         return marker;
     }
+  }
+
+  /**
+   * Wraps the provided behavior in the JS SDK's `SnapshotOptions` shape, or
+   * returns `undefined` when no override was requested so the SDK uses its
+   * default `'none'` behavior.
+   */
+  private buildSnapshotOptions(
+    serverTimestamps: ServerTimestampBehavior | undefined,
+  ): SnapshotOptions | undefined {
+    return serverTimestamps ? { serverTimestamps } : undefined;
+  }
+
+  /**
+   * Reads a snapshot's data with the provided behavior. Centralized so the
+   * `serverTimestamps` option doesn't have to be threaded through every
+   * caller, and so a future option can be added in one place.
+   */
+  private readSnapshotData<T extends DocumentData>(
+    snapshot: FirebaseDocumentSnapshot<T, DocumentData>,
+    options: SnapshotOptions | undefined,
+  ): T | undefined {
+    return options ? snapshot.data(options) : snapshot.data();
   }
 }


### PR DESCRIPTION
A collection of firestore features/fixes. Addresses: #983, #984, #985, #986

For transparency:
- We have tested the following on all platforms (web, android, ios)
- The code was almost entirely AI-generated
- I reviewed the code, but am not experienced in native ios or android development

Actual core changes:
- Fully support `DocumentReference` and `Bytes` data types. Support was hit-or-miss across platforms and reading/writing data types.
- Support queries in `getCountFromServer`. Previously, you could only count an entire collection.
- Support `serverTimestamps` behavior options. The underlying firestore libraries allow for using e.g. "estimate" on pending server timestamps.
- Fix tracking/unsubscribing web snapshot listeners. Previously, they were tracked by `Date`, but this led to collisions in ids (when multiple listeners were set up in the same millisecond) and made it so some listeners could never be stopped.





## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [ ] A changeset has been created (`npm run changeset`). (doesn't work?)
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).
