### PR TITLE
feat(authentication): add `googleServerClientId` config option for iOS Google Sign-In

### DIFF
--- a/.changeset/auth-google-server-client-id-ios.md
+++ b/.changeset/auth-google-server-client-id-ios.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/authentication': minor
+---
+
+feat(authentication): add `googleServerClientId` config option to use a separate web OAuth client as `serverClientID` for Google Sign-In on iOS, so the offline-access `serverAuthCode` is exchangeable server-side

--- a/packages/authentication/README.md
+++ b/packages/authentication/README.md
@@ -96,11 +96,12 @@ For more information, see [Third-Party SDKs](https://github.com/capawesome-team/
 
 These configuration values are available:
 
-| Prop                 | Type                  | Description                                                                                                                                                                                                                                                                                                    | Default            | Since |
-| -------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ----- |
-| **`authDomain`**     | <code>string</code>   | Configure the custom auth domain you want to use. Only available for Android and iOS.                                                                                                                                                                                                                          |                    | 7.3.0 |
-| **`skipNativeAuth`** | <code>boolean</code>  | Configure whether the plugin should skip the native authentication. Only needed if you want to use the Firebase JavaScript SDK. This configuration option has no effect on Firebase account linking. **Note that the plugin may behave differently across the platforms.** Only available for Android and iOS. | <code>false</code> | 0.1.0 |
-| **`providers`**      | <code>string[]</code> | Configure the providers that should be loaded by the plugin. Possible values: `["apple.com", "facebook.com", "gc.apple.com", "github.com", "google.com", "microsoft.com", "playgames.google.com", "twitter.com", "yahoo.com", "phone"]` Only available for Android and iOS.                                    | <code>[]</code>    | 0.1.0 |
+| Prop                       | Type                  | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Default            | Since |
+| -------------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ----- |
+| **`authDomain`**           | <code>string</code>   | Configure the custom auth domain you want to use. Only available for Android and iOS.                                                                                                                                                                                                                          |                    | 7.3.0 |
+| **`skipNativeAuth`**       | <code>boolean</code>  | Configure whether the plugin should skip the native authentication. Only needed if you want to use the Firebase JavaScript SDK. This configuration option has no effect on Firebase account linking. **Note that the plugin may behave differently across the platforms.** Only available for Android and iOS. | <code>false</code> | 0.1.0 |
+| **`providers`**            | <code>string[]</code> | Configure the providers that should be loaded by the plugin. Possible values: `["apple.com", "facebook.com", "gc.apple.com", "github.com", "google.com", "microsoft.com", "playgames.google.com", "twitter.com", "yahoo.com", "phone"]` Only available for Android and iOS.                                    | <code>[]</code>    | 0.1.0 |
+| **`googleServerClientId`** | <code>string</code>   | Configure the OAuth 2.0 web client ID to use as `serverClientID` for Google Sign-In on iOS. When set, Google issues the offline-access auth code (`serverAuthCode`) to this web client, making it exchangeable server-side using the web client's `client_secret`. On Android, the equivalent web client ID is already read from `R.string.default_web_client_id`. Only available for iOS.                                                                                                                                                                                                                                                    |                    | 8.3.0 |
 
 ### Examples
 
@@ -112,7 +113,8 @@ In `capacitor.config.json`:
     "FirebaseAuthentication": {
       "authDomain": undefined,
       "skipNativeAuth": false,
-      "providers": ["apple.com", "facebook.com"]
+      "providers": ["apple.com", "facebook.com"],
+      "googleServerClientId": "1234567890-abcdef.apps.googleusercontent.com"
     }
   }
 }
@@ -131,6 +133,7 @@ const config: CapacitorConfig = {
       authDomain: undefined,
       skipNativeAuth: false,
       providers: ["apple.com", "facebook.com"],
+      googleServerClientId: "1234567890-abcdef.apps.googleusercontent.com",
     },
   },
 };

--- a/packages/authentication/ios/Plugin/FirebaseAuthenticationConfig.swift
+++ b/packages/authentication/ios/Plugin/FirebaseAuthenticationConfig.swift
@@ -2,4 +2,5 @@ public struct FirebaseAuthenticationConfig {
     var skipNativeAuth = false
     var providers = [String]()
     var authDomain: String?
+    var googleServerClientId: String?
 }

--- a/packages/authentication/ios/Plugin/FirebaseAuthenticationPlugin.swift
+++ b/packages/authentication/ios/Plugin/FirebaseAuthenticationPlugin.swift
@@ -736,6 +736,7 @@ public class FirebaseAuthenticationPlugin: CAPPlugin, CAPBridgedPlugin {
         if let providers = getConfig().getArray("providers") as? [String] {
             config.providers = providers
         }
+        config.googleServerClientId = getConfig().getString("googleServerClientId")
 
         return config
     }

--- a/packages/authentication/ios/Plugin/Handlers/GoogleAuthProviderHandler.swift
+++ b/packages/authentication/ios/Plugin/Handlers/GoogleAuthProviderHandler.swift
@@ -31,7 +31,8 @@ class GoogleAuthProviderHandler: NSObject {
     private func startSignInWithGoogleFlow(_ call: CAPPluginCall, isLink: Bool) {
         #if RGCFA_INCLUDE_GOOGLE
         guard let clientId = FirebaseApp.app()?.options.clientID else { return }
-        let config = GIDConfiguration(clientID: clientId, serverClientID: clientId)
+        let serverClientId = pluginImplementation.getConfig().googleServerClientId ?? clientId
+        let config = GIDConfiguration(clientID: clientId, serverClientID: serverClientId)
         GIDSignIn.sharedInstance.configuration = config
         guard let controller = self.pluginImplementation.getPlugin().bridge?.viewController else { return }
         let scopes = call.getArray("scopes", String.self) ?? []

--- a/packages/authentication/src/definitions.ts
+++ b/packages/authentication/src/definitions.ts
@@ -44,6 +44,27 @@ declare module '@capacitor/cli' {
        * @since 0.1.0
        */
       providers?: string[];
+      /**
+       * Configure the OAuth 2.0 web client ID to use as `serverClientID` for
+       * Google Sign-In on iOS.
+       *
+       * When set, the iOS native sign-in sheet still uses the iOS client for
+       * bundle-ID authorization, but Google issues the offline-access auth
+       * code (`serverAuthCode`) to this web client — which is exchangeable
+       * server-side using the web client's `client_secret`. Without this,
+       * Google issues the auth code to the iOS client, which has no
+       * `client_secret` and uses PKCE the SDK does not expose, making the
+       * code unexchangeable.
+       *
+       * On Android, the equivalent web client ID is already read from
+       * `R.string.default_web_client_id` (defined in `google-services.json`).
+       *
+       * Only available for iOS.
+       *
+       * @example "1234567890-abcdef.apps.googleusercontent.com"
+       * @since 8.3.0
+       */
+      googleServerClientId?: string;
     };
   }
 }


### PR DESCRIPTION
## Summary

Adds an optional `googleServerClientId` Capacitor plugin config key for `@capacitor-firebase/authentication`. When set, the iOS handler passes it as `serverClientID` to `GIDConfiguration`, so Google issues the offline-access `serverAuthCode` to the configured web OAuth client (rather than to the iOS client, which is the current hardcoded behavior).

## Problem

The iOS handler at [`GoogleAuthProviderHandler.swift:34`](https://github.com/capawesome-team/capacitor-firebase/blob/main/packages/authentication/ios/Plugin/Handlers/GoogleAuthProviderHandler.swift#L34) currently does:

```swift
let config = GIDConfiguration(clientID: clientId, serverClientID: clientId)
```

Both `clientID` and `serverClientID` point at the iOS OAuth client (read from `FirebaseApp.app()?.options.clientID`). This means:

- The native sign-in sheet authorizes correctly via the iOS bundle ID ✅
- But Google issues the offline-access auth code (`serverAuthCode`) to the **iOS client**, which:
  - Has no `client_secret` (Google does not issue secrets for iOS clients — they're public clients), and
  - Used PKCE internally with a `code_verifier` the iOS Google Sign-In SDK never exposes to the calling app.
- The auth code is therefore unexchangeable server-side — `oauth2.googleapis.com/token` returns `unauthorized_client / "Unauthorized"` for any attempt.

This breaks the canonical Google mobile-OAuth offline-access pattern, where the auth code is intended to be exchanged on a trusted backend for a refresh token.

## Solution

Add an optional `googleServerClientId` config key. When set, the iOS handler uses it as `serverClientID`:

```swift
let serverClientId = pluginImplementation.getConfig().googleServerClientId ?? clientId
let config = GIDConfiguration(clientID: clientId, serverClientID: serverClientId)
```

With this, Google issues the offline-access auth code to the **web** OAuth client (which has a `client_secret`), making it exchangeable server-side via the standard `authorization_code` grant. The iOS native sheet still uses the iOS client for bundle-ID authorization — only the audience of the resulting auth code changes.

This is the canonical pattern Google documents for [the GoogleSignIn iOS SDK](https://developers.google.com/identity/sign-in/ios/offline-access).

## Backward compatibility

100% additive. When `googleServerClientId` is omitted (the default), `serverClientID` falls back to `clientId`, preserving the existing behavior exactly. No consumer is affected unless they explicitly opt in by setting the new key.

## Android note (intentionally not in this PR)

Android already handles this correctly — [`GoogleAuthProviderHandler.java:180`](https://github.com/capawesome-team/capacitor-firebase/blob/main/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/handlers/GoogleAuthProviderHandler.java#L180) calls `.requestServerAuthCode(R.string.default_web_client_id)`, where `default_web_client_id` is auto-generated from `google-services.json`. So no Android changes are needed.

A separate follow-up could add `googleServerClientId` support on Android for users who want to override the auto-generated web client (e.g., to use a different OAuth client than the one Firebase Console created). Not in scope for this PR.

## Changes (5 files + changeset)

- `packages/authentication/ios/Plugin/FirebaseAuthenticationConfig.swift` — add `var googleServerClientId: String?` to the config struct
- `packages/authentication/ios/Plugin/FirebaseAuthenticationPlugin.swift` — read the new key from `getConfig()` in `firebaseAuthenticationConfig()`
- `packages/authentication/ios/Plugin/Handlers/GoogleAuthProviderHandler.swift` — use the value as `serverClientID`, with fallback to `clientId`
- `packages/authentication/src/definitions.ts` — add the typed config key with JSDoc explaining the iOS-only scope + why
- `packages/authentication/README.md` — add the row to the configuration table + the example (please re-run docgen if my manual additions don't match — I wasn't sure if running `npm run build` was expected as part of the PR)
- `.changeset/auth-google-server-client-id-ios.md` — minor bump for `@capacitor-firebase/authentication`

## Usage example

In `capacitor.config.ts`:

```ts
import { CapacitorConfig } from '@capacitor/cli';

const config: CapacitorConfig = {
  plugins: {
    FirebaseAuthentication: {
      providers: ['google.com'],
      // Web OAuth client ID (same one your backend exchanges auth codes with):
      googleServerClientId: '1234567890-abcdef.apps.googleusercontent.com',
    },
  },
};
```

Then call `FirebaseAuthentication.signInWithGoogle()` as usual. The returned `credential.serverAuthCode` is now exchangeable by your backend using the web client's `client_id` + `client_secret`.

## Test Plan

- [x] Verified end-to-end on a physical iPhone with a Brainday production build using a local `patch-package` of the same diff. Native sign-in completes → `serverAuthCode` exchange against `oauth2.googleapis.com/token` returns 200 with a refresh token → refresh token persists to Firestore → Calendar API reconcile succeeds.
- [x] Confirmed the no-config-key fallback preserves existing behavior (since `nil ?? clientId == clientId` matches the unpatched line exactly).
- [ ] Maintainer: please re-run `npm run build` to regenerate any docgen output if my manual README changes need formatting normalization.
- [ ] Maintainer: please review the `@since 8.3.0` JSDoc/changeset tag — adjust if you'd prefer a different target version.

## Motivation

I hit this exactly while building offline Google Calendar sync for an iOS Capacitor app and traced the `unauthorized_client` error back to the hardcoded `serverClientID: clientId` line. The fix has been running in production for [some hours / a day] under a local `patch-package` patch; submitting upstream so the workaround isn't needed and other Capacitor apps can adopt the canonical pattern out of the box.

Happy to address any feedback, split the PR differently, add tests, or rework the docs to match conventions.