### PR TITLE
feat(firestore): support queries in getCountFromServer

### DIFF
--- a/.changeset/firestore-count-from-server-query.md
+++ b/.changeset/firestore-count-from-server-query.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/firestore': minor
+---
+
+feat: support queries in `getCountFromServer`

--- a/packages/firestore/README.md
+++ b/packages/firestore/README.md
@@ -933,9 +933,11 @@ Execute multiple write operations as a single batch.
 
 #### GetCountFromServerOptions
 
-| Prop            | Type                | Description                                                                         | Since |
-| --------------- | ------------------- | ----------------------------------------------------------------------------------- | ----- |
-| **`reference`** | <code>string</code> | The reference as a string, with path components separated by a forward slash (`/`). | 6.4.0 |
+| Prop                   | Type                                                                                      | Description                                                                                      | Since |
+| ---------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ----- |
+| **`reference`**        | <code>string</code>                                                                       | The reference as a string, with path components separated by a forward slash (`/`).              | 6.4.0 |
+| **`compositeFilter`**  | <code><a href="#querycompositefilterconstraint">QueryCompositeFilterConstraint</a></code> | The filter to apply.                                                                             | 8.3.0 |
+| **`queryConstraints`** | <code>QueryNonFilterConstraint[]</code>                                                   | Narrow or order the set of documents to count, but do not explicitly filter for document fields. | 8.3.0 |
 
 
 #### GetDocumentOptions

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestore.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestore.java
@@ -248,9 +248,23 @@ public class FirebaseFirestore {
         getFirebaseFirestoreInstance().useEmulator(host, port);
     }
 
-    public void getCountFromServer(@NonNull GetCountFromServerOptions options, @NonNull NonEmptyResultCallback callback) {
+    public void getCountFromServer(@NonNull GetCountFromServerOptions options, @NonNull NonEmptyResultCallback callback) throws Exception {
         String reference = options.getReference();
+        QueryCompositeFilterConstraint compositeFilter = options.getCompositeFilter();
+        QueryNonFilterConstraint[] queryConstraints = options.getQueryConstraints();
+
         Query query = getFirebaseFirestoreInstance().collection(reference);
+        if (compositeFilter != null) {
+            Filter filter = compositeFilter.toFilter();
+            if (filter != null) {
+                query = query.where(filter);
+            }
+        }
+        if (queryConstraints.length > 0) {
+            for (QueryNonFilterConstraint queryConstraint : queryConstraints) {
+                query = queryConstraint.toQuery(query, getFirebaseFirestoreInstance());
+            }
+        }
         AggregateQuery countQuery = query.count();
 
         countQuery

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestorePlugin.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestorePlugin.java
@@ -430,8 +430,10 @@ public class FirebaseFirestorePlugin extends Plugin {
                 call.reject(ERROR_REFERENCE_MISSING);
                 return;
             }
+            JSObject compositeFilter = call.getObject("compositeFilter", null);
+            JSArray queryConstraints = call.getArray("queryConstraints", null);
 
-            GetCountFromServerOptions options = new GetCountFromServerOptions(reference);
+            GetCountFromServerOptions options = new GetCountFromServerOptions(reference, compositeFilter, queryConstraints);
             NonEmptyResultCallback callback = new NonEmptyResultCallback() {
                 @Override
                 public void success(Result result) {

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/GetCountFromServerOptions.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/GetCountFromServerOptions.java
@@ -1,18 +1,44 @@
 package io.capawesome.capacitorjs.plugins.firebase.firestore.classes.options;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.getcapacitor.JSArray;
+import com.getcapacitor.JSObject;
+import io.capawesome.capacitorjs.plugins.firebase.firestore.FirebaseFirestoreHelper;
+import io.capawesome.capacitorjs.plugins.firebase.firestore.classes.constraints.QueryCompositeFilterConstraint;
+import io.capawesome.capacitorjs.plugins.firebase.firestore.interfaces.QueryNonFilterConstraint;
+import org.json.JSONException;
 
 public class GetCountFromServerOptions {
 
     @NonNull
     private final String reference;
 
-    public GetCountFromServerOptions(@NonNull String reference) {
+    @Nullable
+    private final QueryCompositeFilterConstraint compositeFilter;
+
+    @NonNull
+    private final QueryNonFilterConstraint[] queryConstraints;
+
+    public GetCountFromServerOptions(@NonNull String reference, @Nullable JSObject compositeFilter, @Nullable JSArray queryConstraints)
+        throws JSONException {
         this.reference = reference;
+        this.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter);
+        this.queryConstraints = FirebaseFirestoreHelper.createQueryNonFilterConstraintArrayFromJSArray(queryConstraints);
     }
 
     @NonNull
     public String getReference() {
         return reference;
+    }
+
+    @Nullable
+    public QueryCompositeFilterConstraint getCompositeFilter() {
+        return compositeFilter;
+    }
+
+    @NonNull
+    public QueryNonFilterConstraint[] getQueryConstraints() {
+        return queryConstraints;
     }
 }

--- a/packages/firestore/ios/Plugin/Classes/Options/GetCountFromServerOptions.swift
+++ b/packages/firestore/ios/Plugin/Classes/Options/GetCountFromServerOptions.swift
@@ -1,13 +1,26 @@
 import Foundation
+import Capacitor
 
 @objc public class GetCountFromServerOptions: NSObject {
-    private let reference: String
+    private var reference: String
+    private var compositeFilter: QueryCompositeFilterConstraint?
+    private var queryConstraints: [QueryNonFilterConstraint]
 
-    init(reference: String) {
+    init(reference: String, compositeFilter: JSObject?, queryConstraints: [JSObject]?) {
         self.reference = reference
+        self.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter)
+        self.queryConstraints = FirebaseFirestoreHelper.createQueryNonFilterConstraintArrayFromJSArray(queryConstraints)
     }
 
     func getReference() -> String {
         return reference
+    }
+
+    func getCompositeFilter() -> QueryCompositeFilterConstraint? {
+        return compositeFilter
+    }
+
+    func getQueryConstraints() -> [QueryNonFilterConstraint] {
+        return queryConstraints
     }
 }

--- a/packages/firestore/ios/Plugin/FirebaseFirestore.swift
+++ b/packages/firestore/ios/Plugin/FirebaseFirestore.swift
@@ -248,12 +248,25 @@ private actor ListenerRegistrationMap {
 
     @objc public func getCountFromServer(_ options: GetCountFromServerOptions, completion: @escaping (Result?, Error?) -> Void) {
         let reference = options.getReference()
-        let collectionReference = getFirestoreInstance().collection(reference)
-        let countQuery = collectionReference.count
+        let compositeFilter = options.getCompositeFilter()
+        let queryConstraints = options.getQueryConstraints()
 
         Task {
             do {
-                let snapshot = try await countQuery.getAggregation(source: .server)
+                let collectionReference = getFirestoreInstance().collection(reference)
+                var query = collectionReference as Query
+                if let compositeFilter = compositeFilter {
+                    if let filter = compositeFilter.toFilter() {
+                        query = query.whereFilter(filter)
+                    }
+                }
+                if !queryConstraints.isEmpty {
+                    for queryConstraint in queryConstraints {
+                        query = try await queryConstraint.toQuery(query: query, firestore: getFirestoreInstance())
+                    }
+                }
+
+                let snapshot = try await query.count.getAggregation(source: .server)
                 let result = GetCountFromServerResult(snapshot.count.intValue)
                 completion(result, nil)
             } catch {

--- a/packages/firestore/ios/Plugin/FirebaseFirestorePlugin.swift
+++ b/packages/firestore/ios/Plugin/FirebaseFirestorePlugin.swift
@@ -272,8 +272,10 @@ public class FirebaseFirestorePlugin: CAPPlugin, CAPBridgedPlugin {
             call.reject(errorReferenceMissing)
             return
         }
+        let compositeFilter = call.getObject("compositeFilter")
+        let queryConstraints = call.getArray("queryConstraints", JSObject.self)
 
-        let options = GetCountFromServerOptions(reference: reference)
+        let options = GetCountFromServerOptions(reference: reference, compositeFilter: compositeFilter, queryConstraints: queryConstraints)
 
         implementation?.getCountFromServer(options, completion: { result, error in
             if let error = error {

--- a/packages/firestore/src/definitions.ts
+++ b/packages/firestore/src/definitions.ts
@@ -457,8 +457,7 @@ export interface SnapshotListenerOptions {
 /**
  * @since 5.2.0
  */
-export interface AddDocumentSnapshotListenerOptions
-  extends SnapshotListenerOptions {
+export interface AddDocumentSnapshotListenerOptions extends SnapshotListenerOptions {
   /**
    * The reference as a string, with path components separated by a forward slash (`/`).
    *
@@ -483,8 +482,7 @@ export type AddDocumentSnapshotListenerCallbackEvent<T> = GetDocumentResult<T>;
 /**
  * @since 5.2.0
  */
-export interface AddCollectionSnapshotListenerOptions
-  extends SnapshotListenerOptions {
+export interface AddCollectionSnapshotListenerOptions extends SnapshotListenerOptions {
   /**
    * The reference as a string, with path components separated by a forward slash (`/`).
    *
@@ -522,8 +520,7 @@ export type AddCollectionSnapshotListenerCallbackEvent<T> =
 /**
  * @since 6.1.0
  */
-export interface AddCollectionGroupSnapshotListenerOptions
-  extends SnapshotListenerOptions {
+export interface AddCollectionGroupSnapshotListenerOptions extends SnapshotListenerOptions {
   /**
    * The reference as a string, with path components separated by a forward slash (`/`).
    *
@@ -583,6 +580,18 @@ export interface GetCountFromServerOptions {
    * @since 6.4.0
    */
   reference: string;
+  /**
+   * The filter to apply.
+   *
+   * @since 8.3.0
+   */
+  compositeFilter?: QueryCompositeFilterConstraint;
+  /**
+   * Narrow or order the set of documents to count, but do not explicitly filter for document fields.
+   *
+   * @since 8.3.0
+   */
+  queryConstraints?: QueryNonFilterConstraint[];
 }
 
 /**

--- a/packages/firestore/src/definitions.ts
+++ b/packages/firestore/src/definitions.ts
@@ -457,7 +457,8 @@ export interface SnapshotListenerOptions {
 /**
  * @since 5.2.0
  */
-export interface AddDocumentSnapshotListenerOptions extends SnapshotListenerOptions {
+export interface AddDocumentSnapshotListenerOptions
+  extends SnapshotListenerOptions {
   /**
    * The reference as a string, with path components separated by a forward slash (`/`).
    *
@@ -482,7 +483,8 @@ export type AddDocumentSnapshotListenerCallbackEvent<T> = GetDocumentResult<T>;
 /**
  * @since 5.2.0
  */
-export interface AddCollectionSnapshotListenerOptions extends SnapshotListenerOptions {
+export interface AddCollectionSnapshotListenerOptions
+  extends SnapshotListenerOptions {
   /**
    * The reference as a string, with path components separated by a forward slash (`/`).
    *
@@ -520,7 +522,8 @@ export type AddCollectionSnapshotListenerCallbackEvent<T> =
 /**
  * @since 6.1.0
  */
-export interface AddCollectionGroupSnapshotListenerOptions extends SnapshotListenerOptions {
+export interface AddCollectionGroupSnapshotListenerOptions
+  extends SnapshotListenerOptions {
   /**
    * The reference as a string, with path components separated by a forward slash (`/`).
    *

--- a/packages/firestore/src/web.ts
+++ b/packages/firestore/src/web.ts
@@ -311,10 +311,11 @@ export class FirebaseFirestoreWeb
   public async getCountFromServer(
     options: GetCountFromServerOptions,
   ): Promise<GetCountFromServerResult> {
-    const firestore = getFirestore();
-    const { reference } = options;
-    const coll = collection(firestore, reference);
-    const snapshot = await getCountFromServer(coll);
+    const collectionQuery = await this.buildCollectionQuery(
+      options,
+      'collection',
+    );
+    const snapshot = await getCountFromServer(collectionQuery);
     return { count: snapshot.data().count };
   }
 
@@ -416,6 +417,7 @@ export class FirebaseFirestoreWeb
     options:
       | GetCollectionOptions
       | GetCollectionGroupOptions
+      | GetCountFromServerOptions
       | AddCollectionSnapshotListenerOptions,
     type: 'collection' | 'collectionGroup',
   ): Promise<Query<DocumentData, DocumentData>> {


### PR DESCRIPTION
## Summary
- Adds optional `compositeFilter` and `queryConstraints` to `GetCountFromServerOptions` so callers can count documents in a filtered/limited query, not only entire collections.
- Wires the new options through the Web, iOS, and Android implementations using the same helpers `getCollection` already uses.

Closes #984

## Test plan
- [ ] Call `getCountFromServer` with only `reference` (existing behavior unchanged).
- [ ] Call `getCountFromServer` with a `compositeFilter` (and/or) and verify the count matches a filtered `getCollection`.
- [ ] Call `getCountFromServer` with `queryConstraints` (e.g. `where`, `limit`) and verify the count.
- [ ] Verify on Web, iOS, and Android.