### PR TITLE
fix(firestore): generate unique listener IDs on web

### DIFF
--- a/.changeset/firestore-storage-unique-listener-ids.md
+++ b/.changeset/firestore-storage-unique-listener-ids.md
@@ -1,0 +1,6 @@
+---
+'@capacitor-firebase/firestore': patch
+'@capacitor-firebase/storage': patch
+---
+
+fix: generate unique listener/callback IDs on web so listeners created in the same millisecond do not overwrite each other

--- a/packages/firestore/src/web.ts
+++ b/packages/firestore/src/web.ts
@@ -96,6 +96,7 @@ export class FirebaseFirestoreWeb
   implements FirebaseFirestorePlugin
 {
   private readonly unsubscribesMap: Map<string, Unsubscribe> = new Map();
+  private lastListenerId = 0;
 
   public async addCollectionGroupSnapshotListener<
     T extends DocumentData = DocumentData,
@@ -129,7 +130,7 @@ export class FirebaseFirestoreWeb
       },
       error => callback(null, error),
     );
-    const id = Date.now().toString();
+    const id = this.generateListenerId();
     this.unsubscribesMap.set(id, unsubscribe);
     return id;
   }
@@ -166,7 +167,7 @@ export class FirebaseFirestoreWeb
       },
       error => callback(null, error),
     );
-    const id = Date.now().toString();
+    const id = this.generateListenerId();
     this.unsubscribesMap.set(id, unsubscribe);
     return id;
   }
@@ -220,7 +221,7 @@ export class FirebaseFirestoreWeb
       },
       error => callback(null, error),
     );
-    const id = Date.now().toString();
+    const id = this.generateListenerId();
     this.unsubscribesMap.set(id, unsubscribe);
     return id;
   }
@@ -669,5 +670,9 @@ export class FirebaseFirestoreWeb
       default:
         return marker;
     }
+  }
+
+  private generateListenerId(): string {
+    return (++this.lastListenerId).toString();
   }
 }

--- a/packages/storage/src/web.ts
+++ b/packages/storage/src/web.ts
@@ -43,6 +43,8 @@ export class FirebaseStorageWeb
 {
   public static readonly ERROR_BLOB_MISSING = 'blob must be provided.';
 
+  private lastCallbackId = 0;
+
   public async downloadFile(
     options: DownloadFileOptions,
     callback: DownloadFileCallback,
@@ -63,7 +65,7 @@ export class FirebaseStorageWeb
       .catch(error => {
         callback(null, error);
       });
-    return Date.now().toString();
+    return this.generateCallbackId();
   }
 
   public async deleteFile(options: DeleteFileOptions): Promise<void> {
@@ -179,7 +181,7 @@ export class FirebaseStorageWeb
         callback(result, undefined);
       },
     });
-    return Date.now().toString();
+    return this.generateCallbackId();
   }
 
   public async useEmulator(options: UseEmulatorOptions): Promise<void> {
@@ -198,5 +200,9 @@ export class FirebaseStorageWeb
       completed: snapshot.state === 'success',
     };
     return result;
+  }
+
+  private generateCallbackId(): string {
+    return (++this.lastCallbackId).toString();
   }
 }


### PR DESCRIPTION
## Summary

- Replaces `Date.now().toString()` listener ID generation in `FirebaseFirestoreWeb` with a per-instance incrementing counter, so multiple snapshot listeners registered in the same millisecond no longer collide and overwrite each other in `unsubscribesMap` (the earlier listeners then couldn't be removed).
- Applies the same fix to `FirebaseStorageWeb`, where `downloadFile` and `uploadFile` returned non-unique callback IDs for the same reason.

## Test plan

- [ ] Register two snapshot listeners back-to-back on the same document/collection on web; confirm both receive callbacks and both can be individually removed via `removeSnapshotListener`.
- [ ] Change the document data after removing the first listener; confirm only the still-active listener fires.
- [ ] `npm run build` for both packages succeeds.

Closes #986