### PR TITLE
feat(firestore): support DocumentReference, Bytes, and NaN/Infinity data types

### DIFF
--- a/.changeset/firestore-more-data-types.md
+++ b/.changeset/firestore-more-data-types.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/firestore': minor
+---
+
+feat(firestore): add support for `DocumentReference`, `Bytes`, `NaN`, and `Infinity` data types across all platforms

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestore.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestore.java
@@ -371,7 +371,7 @@ public class FirebaseFirestore {
         this.listenerRegistrationMap.clear();
     }
 
-    private com.google.firebase.firestore.FirebaseFirestore getFirebaseFirestoreInstance() {
+    public com.google.firebase.firestore.FirebaseFirestore getFirebaseFirestoreInstance() {
         String databaseId = config.getDatabaseId();
         if (databaseId != null) {
             return com.google.firebase.firestore.FirebaseFirestore.getInstance(databaseId);

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestoreHelper.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestoreHelper.java
@@ -2,11 +2,14 @@ package io.capawesome.capacitorjs.plugins.firebase.firestore;
 
 import static io.capawesome.capacitorjs.plugins.firebase.firestore.FirebaseFirestorePlugin.ERROR_CODE_PREFIX;
 
+import android.util.Base64;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
 import com.google.firebase.Timestamp;
+import com.google.firebase.firestore.Blob;
+import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FieldValue;
 import com.google.firebase.firestore.FirebaseFirestoreException;
@@ -27,12 +30,15 @@ import org.json.JSONObject;
 
 public class FirebaseFirestoreHelper {
 
-    public static HashMap<String, Object> createHashMapFromJSONObject(JSONObject object) throws JSONException {
+    public static HashMap<String, Object> createHashMapFromJSONObject(
+        JSONObject object,
+        @NonNull com.google.firebase.firestore.FirebaseFirestore firestore
+    ) throws JSONException {
         HashMap<String, Object> map = new HashMap<>();
         Iterator<String> keys = object.keys();
         while (keys.hasNext()) {
             String key = keys.next();
-            Object value = createObjectFromJSValue(object.get(key));
+            Object value = createObjectFromJSValue(object.get(key), firestore);
             map.put(key, value);
         }
         return map;
@@ -45,45 +51,38 @@ public class FirebaseFirestoreHelper {
         }
         JSObject object = new JSObject();
         for (String key : map.keySet()) {
-            Object value = map.get(key);
-            if (value instanceof Timestamp) {
-                value = createJSObjectFromTimestamp((Timestamp) value);
-            } else if (value instanceof GeoPoint) {
-                value = createJSObjectFromGeoPoint((GeoPoint) value);
-            } else if (value instanceof ArrayList) {
-                value = createJSArrayFromArrayList((ArrayList) value);
-            } else if (value instanceof Map) {
-                value = createJSObjectFromMap((Map<String, Object>) value);
-            }
-            object.put(key, value);
+            object.put(key, createJSValueFromNative(map.get(key)));
         }
         return object;
     }
 
-    public static Object createObjectFromJSValue(Object value) throws JSONException {
+    public static Object createObjectFromJSValue(Object value, @NonNull com.google.firebase.firestore.FirebaseFirestore firestore)
+        throws JSONException {
         if (value.toString().equals("null")) {
             return null;
         } else if (value instanceof JSONObject) {
             JSONObject jsonObject = (JSONObject) value;
-            Object nativeValue = createNativeValueFromMarker(jsonObject);
+            Object nativeValue = createNativeValueFromMarker(jsonObject, firestore);
             if (nativeValue != null) {
                 return nativeValue;
             }
-            return createHashMapFromJSONObject(jsonObject);
+            return createHashMapFromJSONObject(jsonObject, firestore);
         } else if (value instanceof JSONArray) {
-            return createArrayListFromJSONArray((JSONArray) value);
+            return createArrayListFromJSONArray((JSONArray) value, firestore);
         } else {
             return value;
         }
     }
 
     @Nullable
-    public static QueryCompositeFilterConstraint createQueryCompositeFilterConstraintFromJSObject(@Nullable JSObject compositeFilter)
-        throws JSONException {
+    public static QueryCompositeFilterConstraint createQueryCompositeFilterConstraintFromJSObject(
+        @Nullable JSObject compositeFilter,
+        @NonNull com.google.firebase.firestore.FirebaseFirestore firestore
+    ) throws JSONException {
         if (compositeFilter == null) {
             return null;
         } else {
-            return new QueryCompositeFilterConstraint(compositeFilter);
+            return new QueryCompositeFilterConstraint(compositeFilter, firestore);
         }
     }
 
@@ -119,7 +118,10 @@ public class FirebaseFirestoreHelper {
     }
 
     @Nullable
-    private static Object createNativeValueFromMarker(@NonNull JSONObject jsonObject) throws JSONException {
+    private static Object createNativeValueFromMarker(
+        @NonNull JSONObject jsonObject,
+        @NonNull com.google.firebase.firestore.FirebaseFirestore firestore
+    ) throws JSONException {
         if (!jsonObject.has("__type__")) {
             return null;
         }
@@ -129,13 +131,19 @@ public class FirebaseFirestoreHelper {
                 return new Timestamp(jsonObject.getLong("seconds"), jsonObject.getInt("nanoseconds"));
             case "geopoint":
                 return new GeoPoint(jsonObject.getDouble("latitude"), jsonObject.getDouble("longitude"));
+            case "documentReference":
+                return firestore.document(jsonObject.getString("path"));
+            case "bytes":
+                return Blob.fromBytes(Base64.decode(jsonObject.getString("bytes"), Base64.NO_WRAP));
+            case "number":
+                return parseSpecialNumber(jsonObject.getString("value"));
             case "serverTimestamp":
                 return FieldValue.serverTimestamp();
             case "arrayUnion": {
                 JSONArray elements = jsonObject.getJSONArray("elements");
                 Object[] args = new Object[elements.length()];
                 for (int i = 0; i < elements.length(); i++) {
-                    args[i] = createObjectFromJSValue(elements.get(i));
+                    args[i] = createObjectFromJSValue(elements.get(i), firestore);
                 }
                 return FieldValue.arrayUnion(args);
             }
@@ -143,7 +151,7 @@ public class FirebaseFirestoreHelper {
                 JSONArray elements = jsonObject.getJSONArray("elements");
                 Object[] args = new Object[elements.length()];
                 for (int i = 0; i < elements.length(); i++) {
-                    args[i] = createObjectFromJSValue(elements.get(i));
+                    args[i] = createObjectFromJSValue(elements.get(i), firestore);
                 }
                 return FieldValue.arrayRemove(args);
             }
@@ -174,31 +182,99 @@ public class FirebaseFirestoreHelper {
         return object;
     }
 
-    private static ArrayList<Object> createArrayListFromJSONArray(JSONArray array) throws JSONException {
+    @NonNull
+    private static JSObject createJSObjectFromDocumentReference(@NonNull DocumentReference reference) {
+        JSObject object = new JSObject();
+        object.put("__type__", "documentReference");
+        object.put("id", reference.getId());
+        object.put("path", reference.getPath());
+        return object;
+    }
+
+    @NonNull
+    private static JSObject createJSObjectFromBlob(@NonNull Blob blob) {
+        JSObject object = new JSObject();
+        object.put("__type__", "bytes");
+        object.put("bytes", Base64.encodeToString(blob.toBytes(), Base64.NO_WRAP));
+        return object;
+    }
+
+    @NonNull
+    private static JSObject createJSObjectFromSpecialNumber(double value) {
+        JSObject object = new JSObject();
+        object.put("__type__", "number");
+        if (Double.isNaN(value)) {
+            object.put("value", "NaN");
+        } else if (value > 0) {
+            object.put("value", "Infinity");
+        } else {
+            object.put("value", "-Infinity");
+        }
+        return object;
+    }
+
+    private static double parseSpecialNumber(String value) {
+        switch (value) {
+            case "NaN":
+                return Double.NaN;
+            case "Infinity":
+                return Double.POSITIVE_INFINITY;
+            case "-Infinity":
+                return Double.NEGATIVE_INFINITY;
+            default:
+                return Double.parseDouble(value);
+        }
+    }
+
+    private static ArrayList<Object> createArrayListFromJSONArray(
+        JSONArray array,
+        @NonNull com.google.firebase.firestore.FirebaseFirestore firestore
+    ) throws JSONException {
         ArrayList<Object> arrayList = new ArrayList<>();
         for (int x = 0; x < array.length(); x++) {
             Object value = array.get(x);
             if (value instanceof JSONObject) {
-                value = createHashMapFromJSONObject((JSONObject) value);
+                JSONObject jsonObject = (JSONObject) value;
+                Object nativeValue = createNativeValueFromMarker(jsonObject, firestore);
+                if (nativeValue != null) {
+                    value = nativeValue;
+                } else {
+                    value = createHashMapFromJSONObject(jsonObject, firestore);
+                }
             } else if (value instanceof JSONArray) {
-                value = createArrayListFromJSONArray((JSONArray) value);
+                value = createArrayListFromJSONArray((JSONArray) value, firestore);
             }
             arrayList.add(value);
         }
         return arrayList;
     }
 
+    @Nullable
+    private static Object createJSValueFromNative(@Nullable Object value) {
+        if (value instanceof Timestamp) {
+            return createJSObjectFromTimestamp((Timestamp) value);
+        } else if (value instanceof GeoPoint) {
+            return createJSObjectFromGeoPoint((GeoPoint) value);
+        } else if (value instanceof DocumentReference) {
+            return createJSObjectFromDocumentReference((DocumentReference) value);
+        } else if (value instanceof Blob) {
+            return createJSObjectFromBlob((Blob) value);
+        } else if (value instanceof Double && !Double.isFinite((Double) value)) {
+            return createJSObjectFromSpecialNumber((Double) value);
+        } else if (value instanceof Float && !Float.isFinite((Float) value)) {
+            return createJSObjectFromSpecialNumber(((Float) value).doubleValue());
+        } else if (value instanceof ArrayList) {
+            return createJSArrayFromArrayList((ArrayList) value);
+        } else if (value instanceof Map) {
+            return createJSObjectFromMap((Map<String, Object>) value);
+        }
+        return value;
+    }
+
     private static JSArray createJSArrayFromArrayList(ArrayList arrayList) {
         JSArray array = new JSArray();
         for (Object value : arrayList) {
-            if (value instanceof Timestamp) {
-                value = createJSObjectFromTimestamp((Timestamp) value);
-            } else if (value instanceof GeoPoint) {
-                value = createJSObjectFromGeoPoint((GeoPoint) value);
-            } else if (value instanceof Map) {
-                value = createJSObjectFromMap((Map<String, Object>) value);
-            }
-            array.put(value);
+            array.put(createJSValueFromNative(value));
         }
         return array;
     }

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestoreHelper.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestoreHelper.java
@@ -237,7 +237,11 @@ public class FirebaseFirestoreHelper {
             case "-Infinity":
                 return Double.NEGATIVE_INFINITY;
             default:
-                return Double.parseDouble(value);
+                try {
+                    return Double.parseDouble(value);
+                } catch (NumberFormatException exception) {
+                    return Double.NaN;
+                }
         }
     }
 

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestorePlugin.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestorePlugin.java
@@ -443,7 +443,12 @@ public class FirebaseFirestorePlugin extends Plugin {
             JSObject compositeFilter = call.getObject("compositeFilter", null);
             JSArray queryConstraints = call.getArray("queryConstraints", null);
 
-            GetCountFromServerOptions options = new GetCountFromServerOptions(reference, compositeFilter, queryConstraints);
+            GetCountFromServerOptions options = new GetCountFromServerOptions(
+                reference,
+                compositeFilter,
+                queryConstraints,
+                implementation.getFirebaseFirestoreInstance()
+            );
             NonEmptyResultCallback callback = new NonEmptyResultCallback() {
                 @Override
                 public void success(Result result) {

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestorePlugin.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestorePlugin.java
@@ -64,7 +64,7 @@ public class FirebaseFirestorePlugin extends Plugin {
                 return;
             }
 
-            AddDocumentOptions options = new AddDocumentOptions(reference, data);
+            AddDocumentOptions options = new AddDocumentOptions(reference, data, implementation.getFirebaseFirestoreInstance());
             NonEmptyResultCallback callback = new NonEmptyResultCallback() {
                 @Override
                 public void success(Result result) {
@@ -100,7 +100,7 @@ public class FirebaseFirestorePlugin extends Plugin {
             }
             boolean merge = call.getBoolean("merge", false);
 
-            SetDocumentOptions options = new SetDocumentOptions(reference, data, merge);
+            SetDocumentOptions options = new SetDocumentOptions(reference, data, merge, implementation.getFirebaseFirestoreInstance());
             EmptyResultCallback callback = new EmptyResultCallback() {
                 @Override
                 public void success() {
@@ -165,7 +165,7 @@ public class FirebaseFirestorePlugin extends Plugin {
                 return;
             }
 
-            UpdateDocumentOptions options = new UpdateDocumentOptions(reference, data);
+            UpdateDocumentOptions options = new UpdateDocumentOptions(reference, data, implementation.getFirebaseFirestoreInstance());
             EmptyResultCallback callback = new EmptyResultCallback() {
                 @Override
                 public void success() {
@@ -225,7 +225,7 @@ public class FirebaseFirestorePlugin extends Plugin {
                 return;
             }
 
-            WriteBatchOptions options = new WriteBatchOptions(operations);
+            WriteBatchOptions options = new WriteBatchOptions(operations, implementation.getFirebaseFirestoreInstance());
             EmptyResultCallback callback = new EmptyResultCallback() {
                 @Override
                 public void success() {
@@ -257,7 +257,12 @@ public class FirebaseFirestorePlugin extends Plugin {
             JSObject compositeFilter = call.getObject("compositeFilter", null);
             JSArray queryConstraints = call.getArray("queryConstraints", null);
 
-            GetCollectionOptions options = new GetCollectionOptions(reference, compositeFilter, queryConstraints);
+            GetCollectionOptions options = new GetCollectionOptions(
+                reference,
+                compositeFilter,
+                queryConstraints,
+                implementation.getFirebaseFirestoreInstance()
+            );
             NonEmptyResultCallback callback = new NonEmptyResultCallback() {
                 @Override
                 public void success(Result result) {
@@ -289,7 +294,12 @@ public class FirebaseFirestorePlugin extends Plugin {
             JSObject compositeFilter = call.getObject("compositeFilter");
             JSArray queryConstraints = call.getArray("queryConstraints");
 
-            GetCollectionGroupOptions options = new GetCollectionGroupOptions(reference, compositeFilter, queryConstraints);
+            GetCollectionGroupOptions options = new GetCollectionGroupOptions(
+                reference,
+                compositeFilter,
+                queryConstraints,
+                implementation.getFirebaseFirestoreInstance()
+            );
             NonEmptyResultCallback callback = new NonEmptyResultCallback() {
                 @Override
                 public void success(Result result) {
@@ -514,7 +524,8 @@ public class FirebaseFirestorePlugin extends Plugin {
                 compositeFilter,
                 queryConstraints,
                 includeMetadataChanges,
-                callbackId
+                callbackId,
+                implementation.getFirebaseFirestoreInstance()
             );
             NonEmptyResultCallback callback = new NonEmptyResultCallback() {
                 @Override
@@ -558,7 +569,8 @@ public class FirebaseFirestorePlugin extends Plugin {
                 compositeFilter,
                 queryConstraints,
                 includeMetadataChanges,
-                callbackId
+                callbackId,
+                implementation.getFirebaseFirestoreInstance()
             );
             NonEmptyResultCallback callback = new NonEmptyResultCallback() {
                 @Override

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/constraints/QueryCompositeFilterConstraint.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/constraints/QueryCompositeFilterConstraint.java
@@ -17,7 +17,8 @@ public class QueryCompositeFilterConstraint implements QueryFilterConstraint {
     @NonNull
     private QueryFilterConstraint[] queryConstraints;
 
-    public QueryCompositeFilterConstraint(JSObject compositeFilter) throws JSONException {
+    public QueryCompositeFilterConstraint(JSObject compositeFilter, @NonNull com.google.firebase.firestore.FirebaseFirestore firestore)
+        throws JSONException {
         this.type = compositeFilter.getString("type");
         JSONArray queryConstraints = compositeFilter.getJSONArray("queryConstraints");
         this.queryConstraints = new QueryFilterConstraint[queryConstraints.length()];
@@ -25,9 +26,9 @@ public class QueryCompositeFilterConstraint implements QueryFilterConstraint {
             JSObject queryConstraint = JSObject.fromJSONObject(queryConstraints.getJSONObject(i));
             String queryConstraintType = queryConstraint.getString("type");
             if (queryConstraintType.equals("where")) {
-                this.queryConstraints[i] = new QueryFieldFilterConstraint(queryConstraint);
+                this.queryConstraints[i] = new QueryFieldFilterConstraint(queryConstraint, firestore);
             } else {
-                this.queryConstraints[i] = new QueryCompositeFilterConstraint(queryConstraint);
+                this.queryConstraints[i] = new QueryCompositeFilterConstraint(queryConstraint, firestore);
             }
         }
     }

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/constraints/QueryFieldFilterConstraint.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/constraints/QueryFieldFilterConstraint.java
@@ -20,10 +20,11 @@ public class QueryFieldFilterConstraint implements QueryFilterConstraint {
     @NonNull
     private Object value;
 
-    public QueryFieldFilterConstraint(JSObject queryConstraint) throws JSONException {
+    public QueryFieldFilterConstraint(JSObject queryConstraint, @NonNull com.google.firebase.firestore.FirebaseFirestore firestore)
+        throws JSONException {
         this.fieldPath = queryConstraint.getString("fieldPath", "");
         this.opStr = queryConstraint.getString("opStr", "");
-        this.value = FirebaseFirestoreHelper.createObjectFromJSValue(queryConstraint.get("value"));
+        this.value = FirebaseFirestoreHelper.createObjectFromJSValue(queryConstraint.get("value"), firestore);
     }
 
     @Nullable

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/AddCollectionGroupSnapshotListenerOptions.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/AddCollectionGroupSnapshotListenerOptions.java
@@ -29,10 +29,11 @@ public class AddCollectionGroupSnapshotListenerOptions {
         @Nullable JSObject compositeFilter,
         @Nullable JSArray queryConstraints,
         @Nullable Boolean includeMetadataChanges,
-        String callbackId
+        String callbackId,
+        @NonNull com.google.firebase.firestore.FirebaseFirestore firestore
     ) throws JSONException {
         this.reference = reference;
-        this.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter);
+        this.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter, firestore);
         this.queryConstraints = FirebaseFirestoreHelper.createQueryNonFilterConstraintArrayFromJSArray(queryConstraints);
         this.includeMetadataChanges = includeMetadataChanges == null ? false : includeMetadataChanges;
         this.callbackId = callbackId;

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/AddCollectionSnapshotListenerOptions.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/AddCollectionSnapshotListenerOptions.java
@@ -30,10 +30,11 @@ public class AddCollectionSnapshotListenerOptions {
         @Nullable JSObject compositeFilter,
         @Nullable JSArray queryConstraints,
         @Nullable Boolean includeMetadataChanges,
-        String callbackId
+        String callbackId,
+        @NonNull com.google.firebase.firestore.FirebaseFirestore firestore
     ) throws JSONException {
         this.reference = reference;
-        this.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter);
+        this.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter, firestore);
         this.queryConstraints = FirebaseFirestoreHelper.createQueryNonFilterConstraintArrayFromJSArray(queryConstraints);
         this.includeMetadataChanges = includeMetadataChanges == null ? false : includeMetadataChanges;
         this.callbackId = callbackId;

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/AddDocumentOptions.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/AddDocumentOptions.java
@@ -1,5 +1,6 @@
 package io.capawesome.capacitorjs.plugins.firebase.firestore.classes.options;
 
+import androidx.annotation.NonNull;
 import com.getcapacitor.JSObject;
 import io.capawesome.capacitorjs.plugins.firebase.firestore.FirebaseFirestoreHelper;
 import java.util.Map;
@@ -10,9 +11,10 @@ public class AddDocumentOptions {
     private String reference;
     private Map<String, Object> data;
 
-    public AddDocumentOptions(String reference, JSObject data) throws JSONException {
+    public AddDocumentOptions(String reference, JSObject data, @NonNull com.google.firebase.firestore.FirebaseFirestore firestore)
+        throws JSONException {
         this.reference = reference;
-        this.data = FirebaseFirestoreHelper.createHashMapFromJSONObject(data);
+        this.data = FirebaseFirestoreHelper.createHashMapFromJSONObject(data, firestore);
     }
 
     public String getReference() {

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/GetCollectionGroupOptions.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/GetCollectionGroupOptions.java
@@ -20,10 +20,14 @@ public class GetCollectionGroupOptions {
     @NonNull
     private QueryNonFilterConstraint[] queryConstraints;
 
-    public GetCollectionGroupOptions(String reference, @Nullable JSObject compositeFilter, @Nullable JSArray queryConstraints)
-        throws JSONException {
+    public GetCollectionGroupOptions(
+        String reference,
+        @Nullable JSObject compositeFilter,
+        @Nullable JSArray queryConstraints,
+        @NonNull com.google.firebase.firestore.FirebaseFirestore firestore
+    ) throws JSONException {
         this.reference = reference;
-        this.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter);
+        this.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter, firestore);
         this.queryConstraints = FirebaseFirestoreHelper.createQueryNonFilterConstraintArrayFromJSArray(queryConstraints);
     }
 

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/GetCollectionOptions.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/GetCollectionOptions.java
@@ -20,10 +20,14 @@ public class GetCollectionOptions {
     @NonNull
     private QueryNonFilterConstraint[] queryConstraints;
 
-    public GetCollectionOptions(String reference, @Nullable JSObject compositeFilter, @Nullable JSArray queryConstraints)
-        throws JSONException {
+    public GetCollectionOptions(
+        String reference,
+        @Nullable JSObject compositeFilter,
+        @Nullable JSArray queryConstraints,
+        @NonNull com.google.firebase.firestore.FirebaseFirestore firestore
+    ) throws JSONException {
         this.reference = reference;
-        this.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter);
+        this.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter, firestore);
         this.queryConstraints = FirebaseFirestoreHelper.createQueryNonFilterConstraintArrayFromJSArray(queryConstraints);
     }
 

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/GetCountFromServerOptions.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/GetCountFromServerOptions.java
@@ -20,10 +20,14 @@ public class GetCountFromServerOptions {
     @NonNull
     private final QueryNonFilterConstraint[] queryConstraints;
 
-    public GetCountFromServerOptions(@NonNull String reference, @Nullable JSObject compositeFilter, @Nullable JSArray queryConstraints)
-        throws JSONException {
+    public GetCountFromServerOptions(
+        @NonNull String reference,
+        @Nullable JSObject compositeFilter,
+        @Nullable JSArray queryConstraints,
+        @NonNull com.google.firebase.firestore.FirebaseFirestore firestore
+    ) throws JSONException {
         this.reference = reference;
-        this.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter);
+        this.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter, firestore);
         this.queryConstraints = FirebaseFirestoreHelper.createQueryNonFilterConstraintArrayFromJSArray(queryConstraints);
     }
 

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/SetDocumentOptions.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/SetDocumentOptions.java
@@ -1,5 +1,6 @@
 package io.capawesome.capacitorjs.plugins.firebase.firestore.classes.options;
 
+import androidx.annotation.NonNull;
 import com.getcapacitor.JSObject;
 import io.capawesome.capacitorjs.plugins.firebase.firestore.FirebaseFirestoreHelper;
 import java.util.Map;
@@ -11,9 +12,14 @@ public class SetDocumentOptions {
     private Map<String, Object> data;
     private boolean merge;
 
-    public SetDocumentOptions(String reference, JSObject data, boolean merge) throws JSONException {
+    public SetDocumentOptions(
+        String reference,
+        JSObject data,
+        boolean merge,
+        @NonNull com.google.firebase.firestore.FirebaseFirestore firestore
+    ) throws JSONException {
         this.reference = reference;
-        this.data = FirebaseFirestoreHelper.createHashMapFromJSONObject(data);
+        this.data = FirebaseFirestoreHelper.createHashMapFromJSONObject(data, firestore);
         this.merge = merge;
     }
 

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/UpdateDocumentOptions.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/UpdateDocumentOptions.java
@@ -1,5 +1,6 @@
 package io.capawesome.capacitorjs.plugins.firebase.firestore.classes.options;
 
+import androidx.annotation.NonNull;
 import com.getcapacitor.JSObject;
 import io.capawesome.capacitorjs.plugins.firebase.firestore.FirebaseFirestoreHelper;
 import java.util.Map;
@@ -10,9 +11,10 @@ public class UpdateDocumentOptions {
     private String reference;
     private Map<String, Object> data;
 
-    public UpdateDocumentOptions(String reference, JSObject data) throws JSONException {
+    public UpdateDocumentOptions(String reference, JSObject data, @NonNull com.google.firebase.firestore.FirebaseFirestore firestore)
+        throws JSONException {
         this.reference = reference;
-        this.data = FirebaseFirestoreHelper.createHashMapFromJSONObject(data);
+        this.data = FirebaseFirestoreHelper.createHashMapFromJSONObject(data, firestore);
     }
 
     public String getReference() {

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/WriteBatchOperation.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/WriteBatchOperation.java
@@ -16,10 +16,11 @@ public class WriteBatchOperation {
     @Nullable
     private SetOptions options;
 
-    public WriteBatchOperation(@NonNull JSObject operation) throws JSONException {
+    public WriteBatchOperation(@NonNull JSObject operation, @NonNull com.google.firebase.firestore.FirebaseFirestore firestore)
+        throws JSONException {
         this.type = operation.getString("type");
         this.reference = operation.getString("reference");
-        this.data = FirebaseFirestoreHelper.createHashMapFromJSONObject(operation.getJSObject("data"));
+        this.data = FirebaseFirestoreHelper.createHashMapFromJSONObject(operation.getJSObject("data"), firestore);
 
         if (operation.has("options") && operation.getJSObject("options") != null) {
             JSObject optsObj = operation.getJSObject("options");

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/WriteBatchOptions.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/classes/options/WriteBatchOptions.java
@@ -10,19 +10,23 @@ public class WriteBatchOptions {
 
     private WriteBatchOperation[] operations;
 
-    public WriteBatchOptions(@Nullable JSArray operations) throws JSONException {
-        this.operations = createWriteBatchOperationArrayFromJSArray(operations);
+    public WriteBatchOptions(@Nullable JSArray operations, @NonNull com.google.firebase.firestore.FirebaseFirestore firestore)
+        throws JSONException {
+        this.operations = createWriteBatchOperationArrayFromJSArray(operations, firestore);
     }
 
     @NonNull
-    private static WriteBatchOperation[] createWriteBatchOperationArrayFromJSArray(@Nullable JSArray data) throws JSONException {
+    private static WriteBatchOperation[] createWriteBatchOperationArrayFromJSArray(
+        @Nullable JSArray data,
+        @NonNull com.google.firebase.firestore.FirebaseFirestore firestore
+    ) throws JSONException {
         if (data == null) {
             return new WriteBatchOperation[0];
         } else {
             WriteBatchOperation[] operations = new WriteBatchOperation[data.length()];
             for (int i = 0; i < data.length(); i++) {
                 JSObject operation = JSObject.fromJSONObject(data.getJSONObject(i));
-                operations[i] = new WriteBatchOperation(operation);
+                operations[i] = new WriteBatchOperation(operation, firestore);
             }
             return operations;
         }

--- a/packages/firestore/ios/Plugin/Classes/Constraints/QueryCompositeFilterConstraint.swift
+++ b/packages/firestore/ios/Plugin/Classes/Constraints/QueryCompositeFilterConstraint.swift
@@ -6,7 +6,7 @@ import Capacitor
     private var type: String
     private var queryConstraints: [QueryFilterConstraint]
 
-    public init(_ compositeFilter: JSObject) {
+    public init(_ compositeFilter: JSObject, firestore: Firestore) {
         self.type = compositeFilter["type"] as? String ?? ""
         let queryConstraints = compositeFilter["queryConstraints"] as? [JSObject]
         self.queryConstraints = []
@@ -14,10 +14,10 @@ import Capacitor
             for queryConstraint in queryConstraints {
                 let queryConstraintType = queryConstraint["type"] as? String ?? ""
                 if queryConstraintType == "where" {
-                    let queryFieldFilterConstraint = QueryFieldFilterConstraint(queryConstraint)
+                    let queryFieldFilterConstraint = QueryFieldFilterConstraint(queryConstraint, firestore: firestore)
                     self.queryConstraints.append(queryFieldFilterConstraint)
                 } else {
-                    let queryCompositeFilterConstraint = QueryCompositeFilterConstraint(queryConstraint)
+                    let queryCompositeFilterConstraint = QueryCompositeFilterConstraint(queryConstraint, firestore: firestore)
                     self.queryConstraints.append(queryCompositeFilterConstraint)
                 }
             }

--- a/packages/firestore/ios/Plugin/Classes/Constraints/QueryFieldFilterConstraint.swift
+++ b/packages/firestore/ios/Plugin/Classes/Constraints/QueryFieldFilterConstraint.swift
@@ -7,11 +7,11 @@ import FirebaseFirestore
     private var opStr: String
     private var value: Any
 
-    public init(_ queryConstraint: JSObject) {
+    public init(_ queryConstraint: JSObject, firestore: Firestore) {
         self.fieldPath = queryConstraint["fieldPath"] as? String ?? ""
         self.opStr = queryConstraint["opStr"] as? String ?? ""
         let rawValue = queryConstraint["value"] as Any
-        self.value = FirebaseFirestoreHelper.createNativeValue(rawValue)
+        self.value = FirebaseFirestoreHelper.createNativeValue(rawValue, firestore: firestore)
     }
 
     public func toFilter() -> Filter? {

--- a/packages/firestore/ios/Plugin/Classes/Options/AddCollectionGroupSnapshotListenerOptions.swift
+++ b/packages/firestore/ios/Plugin/Classes/Options/AddCollectionGroupSnapshotListenerOptions.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Capacitor
+import FirebaseFirestore
 
 @objc public class AddCollectionGroupSnapshotListenerOptions: NSObject {
     private var reference: String
@@ -8,9 +9,16 @@ import Capacitor
     private var includeMetadataChanges: Bool
     private var callbackId: String
 
-    init(reference: String, compositeFilter: JSObject?, queryConstraints: [JSObject]?, includeMetadataChanges: Bool, callbackId: String) {
+    init(
+        reference: String,
+        compositeFilter: JSObject?,
+        queryConstraints: [JSObject]?,
+        includeMetadataChanges: Bool,
+        callbackId: String,
+        firestore: Firestore
+    ) {
         self.reference = reference
-        self.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter)
+        self.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter, firestore: firestore)
         self.queryConstraints = FirebaseFirestoreHelper.createQueryNonFilterConstraintArrayFromJSArray(queryConstraints)
         self.includeMetadataChanges = includeMetadataChanges
         self.callbackId = callbackId

--- a/packages/firestore/ios/Plugin/Classes/Options/AddCollectionSnapshotListenerOptions.swift
+++ b/packages/firestore/ios/Plugin/Classes/Options/AddCollectionSnapshotListenerOptions.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Capacitor
+import FirebaseFirestore
 
 @objc public class AddCollectionSnapshotListenerOptions: NSObject {
     private var reference: String
@@ -8,9 +9,16 @@ import Capacitor
     private var includeMetadataChanges: Bool
     private var callbackId: String
 
-    init(reference: String, compositeFilter: JSObject?, queryConstraints: [JSObject]?, includeMetadataChanges: Bool, callbackId: String) {
+    init(
+        reference: String,
+        compositeFilter: JSObject?,
+        queryConstraints: [JSObject]?,
+        includeMetadataChanges: Bool,
+        callbackId: String,
+        firestore: Firestore
+    ) {
         self.reference = reference
-        self.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter)
+        self.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter, firestore: firestore)
         self.queryConstraints = FirebaseFirestoreHelper.createQueryNonFilterConstraintArrayFromJSArray(queryConstraints)
         self.includeMetadataChanges = includeMetadataChanges
         self.callbackId = callbackId

--- a/packages/firestore/ios/Plugin/Classes/Options/AddDocumentOptions.swift
+++ b/packages/firestore/ios/Plugin/Classes/Options/AddDocumentOptions.swift
@@ -1,13 +1,14 @@
 import Foundation
 import Capacitor
+import FirebaseFirestore
 
 @objc public class AddDocumentOptions: NSObject {
     private var reference: String
     private var data: [String: Any]
 
-    init(reference: String, data: JSObject) {
+    init(reference: String, data: JSObject, firestore: Firestore) {
         self.reference = reference
-        self.data = FirebaseFirestoreHelper.createHashMapFromJSObject(data)
+        self.data = FirebaseFirestoreHelper.createHashMapFromJSObject(data, firestore: firestore)
     }
 
     func getReference() -> String {

--- a/packages/firestore/ios/Plugin/Classes/Options/GetCollectionGroupOptions.swift
+++ b/packages/firestore/ios/Plugin/Classes/Options/GetCollectionGroupOptions.swift
@@ -1,14 +1,15 @@
 import Foundation
 import Capacitor
+import FirebaseFirestore
 
 @objc public class GetCollectionGroupOptions: NSObject {
     private var reference: String
     private var compositeFilter: QueryCompositeFilterConstraint?
     private var queryConstraints: [QueryNonFilterConstraint]
 
-    init(reference: String, compositeFilter: JSObject?, queryConstraints: [JSObject]?) {
+    init(reference: String, compositeFilter: JSObject?, queryConstraints: [JSObject]?, firestore: Firestore) {
         self.reference = reference
-        self.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter)
+        self.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter, firestore: firestore)
         self.queryConstraints = FirebaseFirestoreHelper.createQueryNonFilterConstraintArrayFromJSArray(queryConstraints)
     }
 

--- a/packages/firestore/ios/Plugin/Classes/Options/GetCollectionOptions.swift
+++ b/packages/firestore/ios/Plugin/Classes/Options/GetCollectionOptions.swift
@@ -1,14 +1,15 @@
 import Foundation
 import Capacitor
+import FirebaseFirestore
 
 @objc public class GetCollectionOptions: NSObject {
     private var reference: String
     private var compositeFilter: QueryCompositeFilterConstraint?
     private var queryConstraints: [QueryNonFilterConstraint]
 
-    init(reference: String, compositeFilter: JSObject?, queryConstraints: [JSObject]?) {
+    init(reference: String, compositeFilter: JSObject?, queryConstraints: [JSObject]?, firestore: Firestore) {
         self.reference = reference
-        self.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter)
+        self.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter, firestore: firestore)
         self.queryConstraints = FirebaseFirestoreHelper.createQueryNonFilterConstraintArrayFromJSArray(queryConstraints)
     }
 

--- a/packages/firestore/ios/Plugin/Classes/Options/GetCountFromServerOptions.swift
+++ b/packages/firestore/ios/Plugin/Classes/Options/GetCountFromServerOptions.swift
@@ -1,14 +1,15 @@
 import Foundation
 import Capacitor
+import FirebaseFirestore
 
 @objc public class GetCountFromServerOptions: NSObject {
     private var reference: String
     private var compositeFilter: QueryCompositeFilterConstraint?
     private var queryConstraints: [QueryNonFilterConstraint]
 
-    init(reference: String, compositeFilter: JSObject?, queryConstraints: [JSObject]?) {
+    init(reference: String, compositeFilter: JSObject?, queryConstraints: [JSObject]?, firestore: Firestore) {
         self.reference = reference
-        self.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter)
+        self.compositeFilter = FirebaseFirestoreHelper.createQueryCompositeFilterConstraintFromJSObject(compositeFilter, firestore: firestore)
         self.queryConstraints = FirebaseFirestoreHelper.createQueryNonFilterConstraintArrayFromJSArray(queryConstraints)
     }
 

--- a/packages/firestore/ios/Plugin/Classes/Options/SetDocumentOptions.swift
+++ b/packages/firestore/ios/Plugin/Classes/Options/SetDocumentOptions.swift
@@ -1,14 +1,15 @@
 import Foundation
 import Capacitor
+import FirebaseFirestore
 
 @objc public class SetDocumentOptions: NSObject {
     private var reference: String
     private var data: [String: Any]
     private var merge: Bool
 
-    init(reference: String, data: JSObject, merge: Bool) {
+    init(reference: String, data: JSObject, merge: Bool, firestore: Firestore) {
         self.reference = reference
-        self.data = FirebaseFirestoreHelper.createHashMapFromJSObject(data)
+        self.data = FirebaseFirestoreHelper.createHashMapFromJSObject(data, firestore: firestore)
         self.merge = merge
     }
 

--- a/packages/firestore/ios/Plugin/Classes/Options/UpdateDocumentOptions.swift
+++ b/packages/firestore/ios/Plugin/Classes/Options/UpdateDocumentOptions.swift
@@ -1,13 +1,14 @@
 import Foundation
 import Capacitor
+import FirebaseFirestore
 
 @objc public class UpdateDocumentOptions: NSObject {
     private var reference: String
     private var data: [String: Any]
 
-    init(reference: String, data: JSObject) {
+    init(reference: String, data: JSObject, firestore: Firestore) {
         self.reference = reference
-        self.data = FirebaseFirestoreHelper.createHashMapFromJSObject(data)
+        self.data = FirebaseFirestoreHelper.createHashMapFromJSObject(data, firestore: firestore)
     }
 
     func getReference() -> String {

--- a/packages/firestore/ios/Plugin/Classes/Options/WriteBatchOperation.swift
+++ b/packages/firestore/ios/Plugin/Classes/Options/WriteBatchOperation.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Capacitor
+import FirebaseFirestore
 
 @objc public class SetOptions: NSObject {
     private var merge: Bool
@@ -19,10 +20,10 @@ import Capacitor
     private var data: [String: Any]
     private var options: SetOptions?
 
-    init(_ operation: JSObject) {
+    init(_ operation: JSObject, firestore: Firestore) {
         self.type = operation["type"] as? String ?? ""
         self.reference = operation["reference"] as? String ?? ""
-        self.data = FirebaseFirestoreHelper.createHashMapFromJSObject(operation["data"] as? JSObject ?? [:])
+        self.data = FirebaseFirestoreHelper.createHashMapFromJSObject(operation["data"] as? JSObject ?? [:], firestore: firestore)
         if let optsObj = operation["options"] as? JSObject {
             self.options = SetOptions(optsObj)
         } else {

--- a/packages/firestore/ios/Plugin/Classes/Options/WriteBatchOptions.swift
+++ b/packages/firestore/ios/Plugin/Classes/Options/WriteBatchOptions.swift
@@ -1,21 +1,22 @@
 import Foundation
 import Capacitor
+import FirebaseFirestore
 
 @objc public class WriteBatchOptions: NSObject {
     private var operations: [WriteBatchOperation]
 
-    init(operations: [JSObject]) {
-        self.operations = WriteBatchOptions.createWriteBatchOperationArrayFromJSArray(operations)
+    init(operations: [JSObject], firestore: Firestore) {
+        self.operations = WriteBatchOptions.createWriteBatchOperationArrayFromJSArray(operations, firestore: firestore)
     }
 
     public func getOperations() -> [WriteBatchOperation] {
         return self.operations
     }
 
-    private static func createWriteBatchOperationArrayFromJSArray(_ data: [JSObject]) -> [WriteBatchOperation] {
+    private static func createWriteBatchOperationArrayFromJSArray(_ data: [JSObject], firestore: Firestore) -> [WriteBatchOperation] {
         var operations: [WriteBatchOperation] = []
         for item in data {
-            operations.append(WriteBatchOperation(item))
+            operations.append(WriteBatchOperation(item, firestore: firestore))
         }
         return operations
     }

--- a/packages/firestore/ios/Plugin/FirebaseFirestore.swift
+++ b/packages/firestore/ios/Plugin/FirebaseFirestore.swift
@@ -369,7 +369,7 @@ private actor ListenerRegistrationMap {
         }
     }
 
-    private func getFirestoreInstance() -> Firestore {
+    public func getFirestoreInstance() -> Firestore {
         if let databaseId = config.databaseId {
             return Firestore.firestore(database: databaseId)
         }

--- a/packages/firestore/ios/Plugin/FirebaseFirestoreHelper.swift
+++ b/packages/firestore/ios/Plugin/FirebaseFirestoreHelper.swift
@@ -226,8 +226,8 @@ public class FirebaseFirestoreHelper {
     }
 
     private static func createJSArrayFromArray(_ array: [Any]) -> [Any] {
-        return array.compactMap { item -> Any? in
-            return createJSValue(value: item)
+        return array.map { item -> Any in
+            return createJSValue(value: item) ?? NSNull()
         }
     }
 

--- a/packages/firestore/ios/Plugin/FirebaseFirestoreHelper.swift
+++ b/packages/firestore/ios/Plugin/FirebaseFirestoreHelper.swift
@@ -3,11 +3,11 @@ import FirebaseFirestore
 import Capacitor
 
 public class FirebaseFirestoreHelper {
-    public static func createHashMapFromJSObject(_ object: JSObject) -> [String: Any] {
+    public static func createHashMapFromJSObject(_ object: JSObject, firestore: Firestore) -> [String: Any] {
         var map: [String: Any] = [:]
         for key in object.keys {
             if let value = object[key] {
-                map[key] = createNativeValue(value)
+                map[key] = createNativeValue(value, firestore: firestore)
             }
         }
         return map
@@ -24,9 +24,12 @@ public class FirebaseFirestoreHelper {
         return object
     }
 
-    public static func createQueryCompositeFilterConstraintFromJSObject(_ compositeFilter: JSObject?) -> QueryCompositeFilterConstraint? {
+    public static func createQueryCompositeFilterConstraintFromJSObject(
+        _ compositeFilter: JSObject?,
+        firestore: Firestore
+    ) -> QueryCompositeFilterConstraint? {
         if let compositeFilter = compositeFilter {
-            return QueryCompositeFilterConstraint(compositeFilter)
+            return QueryCompositeFilterConstraint(compositeFilter, firestore: firestore)
         } else {
             return nil
         }
@@ -60,26 +63,26 @@ public class FirebaseFirestoreHelper {
         }
     }
 
-    public static func createNativeValue(_ value: Any) -> Any {
+    public static func createNativeValue(_ value: Any, firestore: Firestore) -> Any {
         if let dict = value as? [String: Any], let type = dict["__type__"] as? String {
-            if let markerValue = createNativeValueFromMarker(type: type, dict: dict) {
+            if let markerValue = createNativeValueFromMarker(type: type, dict: dict, firestore: firestore) {
                 return markerValue
             }
         }
         if let dict = value as? [String: Any] {
             var result: [String: Any] = [:]
             for (key, val) in dict {
-                result[key] = createNativeValue(val)
+                result[key] = createNativeValue(val, firestore: firestore)
             }
             return result
         }
         if let array = value as? [Any] {
-            return array.map { createNativeValue($0) }
+            return array.map { createNativeValue($0, firestore: firestore) }
         }
         return value
     }
 
-    private static func createNativeValueFromMarker(type: String, dict: [String: Any]) -> Any? {
+    private static func createNativeValueFromMarker(type: String, dict: [String: Any], firestore: Firestore) -> Any? {
         switch type {
         case "timestamp":
             guard let seconds = (dict["seconds"] as? NSNumber)?.int64Value,
@@ -89,13 +92,23 @@ public class FirebaseFirestoreHelper {
             guard let latitude = (dict["latitude"] as? NSNumber)?.doubleValue,
                   let longitude = (dict["longitude"] as? NSNumber)?.doubleValue else { return nil }
             return GeoPoint(latitude: latitude, longitude: longitude)
+        case "documentReference":
+            guard let path = dict["path"] as? String else { return nil }
+            return firestore.document(path)
+        case "bytes":
+            guard let base64 = dict["bytes"] as? String,
+                  let data = Data(base64Encoded: base64) else { return nil }
+            return data
+        case "number":
+            guard let value = dict["value"] as? String else { return nil }
+            return parseSpecialNumber(value)
         case "serverTimestamp":
             return FieldValue.serverTimestamp()
         case "arrayUnion":
-            let elements = (dict["elements"] as? [Any] ?? []).map { createNativeValue($0) }
+            let elements = (dict["elements"] as? [Any] ?? []).map { createNativeValue($0, firestore: firestore) }
             return FieldValue.arrayUnion(elements)
         case "arrayRemove":
-            let elements = (dict["elements"] as? [Any] ?? []).map { createNativeValue($0) }
+            let elements = (dict["elements"] as? [Any] ?? []).map { createNativeValue($0, firestore: firestore) }
             return FieldValue.arrayRemove(elements)
         case "delete":
             return FieldValue.delete()
@@ -121,6 +134,15 @@ public class FirebaseFirestoreHelper {
         }
         if let geoPoint = value as? GeoPoint {
             return createJSObjectFromGeoPoint(geoPoint) as JSValue
+        }
+        if let documentReference = value as? DocumentReference {
+            return createJSObjectFromDocumentReference(documentReference) as JSValue
+        }
+        if let data = value as? Data {
+            return createJSObjectFromData(data) as JSValue
+        }
+        if let number = value as? NSNumber, isSpecialNumber(number) {
+            return createJSObjectFromSpecialNumber(number.doubleValue) as JSValue
         }
         if let array = value as? [Any] {
             return createJSArrayFromArray(array) as JSValue
@@ -153,21 +175,59 @@ public class FirebaseFirestoreHelper {
         return object
     }
 
+    private static func createJSObjectFromDocumentReference(_ reference: DocumentReference) -> JSObject {
+        var object: JSObject = [:]
+        object["__type__"] = "documentReference"
+        object["id"] = reference.documentID
+        object["path"] = reference.path
+        return object
+    }
+
+    private static func createJSObjectFromData(_ data: Data) -> JSObject {
+        var object: JSObject = [:]
+        object["__type__"] = "bytes"
+        object["bytes"] = data.base64EncodedString()
+        return object
+    }
+
+    private static func createJSObjectFromSpecialNumber(_ value: Double) -> JSObject {
+        var object: JSObject = [:]
+        object["__type__"] = "number"
+        if value.isNaN {
+            object["value"] = "NaN"
+        } else if value > 0 {
+            object["value"] = "Infinity"
+        } else {
+            object["value"] = "-Infinity"
+        }
+        return object
+    }
+
+    private static func isSpecialNumber(_ number: NSNumber) -> Bool {
+        let type = String(cString: number.objCType)
+        guard type == "d" || type == "f" else {
+            return false
+        }
+        let value = number.doubleValue
+        return value.isNaN || value.isInfinite
+    }
+
+    private static func parseSpecialNumber(_ value: String) -> Double {
+        switch value {
+        case "NaN":
+            return Double.nan
+        case "Infinity":
+            return Double.infinity
+        case "-Infinity":
+            return -Double.infinity
+        default:
+            return Double(value) ?? Double.nan
+        }
+    }
+
     private static func createJSArrayFromArray(_ array: [Any]) -> [Any] {
-        return array.map { item -> Any in
-            if let timestamp = item as? Timestamp {
-                return createJSObjectFromTimestamp(timestamp)
-            }
-            if let geoPoint = item as? GeoPoint {
-                return createJSObjectFromGeoPoint(geoPoint)
-            }
-            if let dict = item as? [String: Any] {
-                return createJSObjectFromHashMap(dict) as Any
-            }
-            if let arr = item as? [Any] {
-                return createJSArrayFromArray(arr)
-            }
-            return item
+        return array.compactMap { item -> Any? in
+            return createJSValue(value: item)
         }
     }
 

--- a/packages/firestore/ios/Plugin/FirebaseFirestorePlugin.swift
+++ b/packages/firestore/ios/Plugin/FirebaseFirestorePlugin.swift
@@ -310,7 +310,11 @@ public class FirebaseFirestorePlugin: CAPPlugin, CAPBridgedPlugin {
         let compositeFilter = call.getObject("compositeFilter")
         let queryConstraints = call.getArray("queryConstraints", JSObject.self)
 
-        let options = GetCountFromServerOptions(reference: reference, compositeFilter: compositeFilter, queryConstraints: queryConstraints)
+        guard let firestore = implementation?.getFirestoreInstance() else {
+            call.reject(errorImplementationMissing)
+            return
+        }
+        let options = GetCountFromServerOptions(reference: reference, compositeFilter: compositeFilter, queryConstraints: queryConstraints, firestore: firestore)
 
         implementation?.getCountFromServer(options, completion: { result, error in
             if let error = error {

--- a/packages/firestore/ios/Plugin/FirebaseFirestorePlugin.swift
+++ b/packages/firestore/ios/Plugin/FirebaseFirestorePlugin.swift
@@ -35,6 +35,7 @@ public class FirebaseFirestorePlugin: CAPPlugin, CAPBridgedPlugin {
     public let errorOperationsMissing = "operations must be provided."
     public let errorHostMissing = "host must be provided."
     public let errorCallbackIdMissing = "callbackId must be provided."
+    public let errorImplementationMissing = "implementation is not initialized."
     private var implementation: FirebaseFirestore?
     private var pluginCallMap: [String: CAPPluginCall] = [:]
 
@@ -52,7 +53,11 @@ public class FirebaseFirestorePlugin: CAPPlugin, CAPBridgedPlugin {
             return
         }
 
-        let options = AddDocumentOptions(reference: reference, data: data)
+        guard let firestore = implementation?.getFirestoreInstance() else {
+            call.reject(errorImplementationMissing)
+            return
+        }
+        let options = AddDocumentOptions(reference: reference, data: data, firestore: firestore)
 
         implementation?.addDocument(options, completion: { result, error in
             if let error = error {
@@ -77,7 +82,11 @@ public class FirebaseFirestorePlugin: CAPPlugin, CAPBridgedPlugin {
         }
         let merge = call.getBool("merge", false)
 
-        let options = SetDocumentOptions(reference: reference, data: data, merge: merge)
+        guard let firestore = implementation?.getFirestoreInstance() else {
+            call.reject(errorImplementationMissing)
+            return
+        }
+        let options = SetDocumentOptions(reference: reference, data: data, merge: merge, firestore: firestore)
 
         implementation?.setDocument(options, completion: { error in
             if let error = error {
@@ -119,7 +128,11 @@ public class FirebaseFirestorePlugin: CAPPlugin, CAPBridgedPlugin {
             return
         }
 
-        let options = UpdateDocumentOptions(reference: reference, data: data)
+        guard let firestore = implementation?.getFirestoreInstance() else {
+            call.reject(errorImplementationMissing)
+            return
+        }
+        let options = UpdateDocumentOptions(reference: reference, data: data, firestore: firestore)
 
         implementation?.updateDocument(options, completion: { error in
             if let error = error {
@@ -155,7 +168,11 @@ public class FirebaseFirestorePlugin: CAPPlugin, CAPBridgedPlugin {
             return
         }
 
-        let options = WriteBatchOptions(operations: operations)
+        guard let firestore = implementation?.getFirestoreInstance() else {
+            call.reject(errorImplementationMissing)
+            return
+        }
+        let options = WriteBatchOptions(operations: operations, firestore: firestore)
 
         implementation?.writeBatch(options, completion: { error in
             if let error = error {
@@ -175,7 +192,16 @@ public class FirebaseFirestorePlugin: CAPPlugin, CAPBridgedPlugin {
         let compositeFilter = call.getObject("compositeFilter")
         let queryConstraints = call.getArray("queryConstraints", JSObject.self)
 
-        let options = GetCollectionOptions(reference: reference, compositeFilter: compositeFilter, queryConstraints: queryConstraints)
+        guard let firestore = implementation?.getFirestoreInstance() else {
+            call.reject(errorImplementationMissing)
+            return
+        }
+        let options = GetCollectionOptions(
+            reference: reference,
+            compositeFilter: compositeFilter,
+            queryConstraints: queryConstraints,
+            firestore: firestore
+        )
 
         implementation?.getCollection(options, completion: { result, error in
             if let error = error {
@@ -197,7 +223,16 @@ public class FirebaseFirestorePlugin: CAPPlugin, CAPBridgedPlugin {
         let compositeFilter = call.getObject("compositeFilter")
         let queryConstraints = call.getArray("queryConstraints", JSObject.self)
 
-        let options = GetCollectionGroupOptions(reference: reference, compositeFilter: compositeFilter, queryConstraints: queryConstraints)
+        guard let firestore = implementation?.getFirestoreInstance() else {
+            call.reject(errorImplementationMissing)
+            return
+        }
+        let options = GetCollectionGroupOptions(
+            reference: reference,
+            compositeFilter: compositeFilter,
+            queryConstraints: queryConstraints,
+            firestore: firestore
+        )
 
         implementation?.getCollectionGroup(options, completion: { result, error in
             if let error = error {
@@ -333,7 +368,18 @@ public class FirebaseFirestorePlugin: CAPPlugin, CAPBridgedPlugin {
 
         self.pluginCallMap[callbackId] = call
 
-        let options = AddCollectionSnapshotListenerOptions(reference: reference, compositeFilter: compositeFilter, queryConstraints: queryConstraints, includeMetadataChanges: includeMetadataChanges, callbackId: callbackId)
+        guard let firestore = implementation?.getFirestoreInstance() else {
+            call.reject(errorImplementationMissing)
+            return
+        }
+        let options = AddCollectionSnapshotListenerOptions(
+            reference: reference,
+            compositeFilter: compositeFilter,
+            queryConstraints: queryConstraints,
+            includeMetadataChanges: includeMetadataChanges,
+            callbackId: callbackId,
+            firestore: firestore
+        )
 
         do {
             implementation?.addCollectionSnapshotListener(options, completion: { result, error in
@@ -369,7 +415,18 @@ public class FirebaseFirestorePlugin: CAPPlugin, CAPBridgedPlugin {
 
         self.pluginCallMap[callbackId] = call
 
-        let options = AddCollectionGroupSnapshotListenerOptions(reference: reference, compositeFilter: compositeFilter, queryConstraints: queryConstraints, includeMetadataChanges: includeMetadataChanges, callbackId: callbackId)
+        guard let firestore = implementation?.getFirestoreInstance() else {
+            call.reject(errorImplementationMissing)
+            return
+        }
+        let options = AddCollectionGroupSnapshotListenerOptions(
+            reference: reference,
+            compositeFilter: compositeFilter,
+            queryConstraints: queryConstraints,
+            includeMetadataChanges: includeMetadataChanges,
+            callbackId: callbackId,
+            firestore: firestore
+        )
 
         do {
             implementation?.addCollectionGroupSnapshotListener(options, completion: { result, error in

--- a/packages/firestore/src/bytes.ts
+++ b/packages/firestore/src/bytes.ts
@@ -1,0 +1,39 @@
+export class Bytes {
+  private readonly base64: string;
+
+  private constructor(base64: string) {
+    this.base64 = base64;
+  }
+
+  static fromBase64String(base64: string): Bytes {
+    return new Bytes(base64);
+  }
+
+  static fromUint8Array(array: Uint8Array): Bytes {
+    let binary = '';
+    for (let i = 0; i < array.byteLength; i++) {
+      binary += String.fromCharCode(array[i]);
+    }
+    return new Bytes(btoa(binary));
+  }
+
+  toBase64(): string {
+    return this.base64;
+  }
+
+  toUint8Array(): Uint8Array {
+    const binary = atob(this.base64);
+    const array = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      array[i] = binary.charCodeAt(i);
+    }
+    return array;
+  }
+
+  toJSON(): { __type__: 'bytes'; bytes: string } {
+    return {
+      __type__: 'bytes',
+      bytes: this.base64,
+    };
+  }
+}

--- a/packages/firestore/src/bytes.ts
+++ b/packages/firestore/src/bytes.ts
@@ -10,11 +10,15 @@ export class Bytes {
   }
 
   static fromUint8Array(array: Uint8Array): Bytes {
-    let binary = '';
-    for (let i = 0; i < array.byteLength; i++) {
-      binary += String.fromCharCode(array[i]);
+    const chunkSize = 0x8000;
+    const chunks: string[] = [];
+    for (let i = 0; i < array.byteLength; i += chunkSize) {
+      const chunk = array.subarray(i, i + chunkSize);
+      chunks.push(
+        String.fromCharCode.apply(null, chunk as unknown as number[]),
+      );
     }
-    return new Bytes(btoa(binary));
+    return new Bytes(btoa(chunks.join('')));
   }
 
   toBase64(): string {

--- a/packages/firestore/src/definitions.ts
+++ b/packages/firestore/src/definitions.ts
@@ -457,8 +457,7 @@ export interface SnapshotListenerOptions {
 /**
  * @since 5.2.0
  */
-export interface AddDocumentSnapshotListenerOptions
-  extends SnapshotListenerOptions {
+export interface AddDocumentSnapshotListenerOptions extends SnapshotListenerOptions {
   /**
    * The reference as a string, with path components separated by a forward slash (`/`).
    *
@@ -483,8 +482,7 @@ export type AddDocumentSnapshotListenerCallbackEvent<T> = GetDocumentResult<T>;
 /**
  * @since 5.2.0
  */
-export interface AddCollectionSnapshotListenerOptions
-  extends SnapshotListenerOptions {
+export interface AddCollectionSnapshotListenerOptions extends SnapshotListenerOptions {
   /**
    * The reference as a string, with path components separated by a forward slash (`/`).
    *
@@ -522,8 +520,7 @@ export type AddCollectionSnapshotListenerCallbackEvent<T> =
 /**
  * @since 6.1.0
  */
-export interface AddCollectionGroupSnapshotListenerOptions
-  extends SnapshotListenerOptions {
+export interface AddCollectionGroupSnapshotListenerOptions extends SnapshotListenerOptions {
   /**
    * The reference as a string, with path components separated by a forward slash (`/`).
    *
@@ -951,6 +948,44 @@ export interface FirestoreDocumentReference {
    * @since 8.3.0
    */
   path: string;
+}
+
+/**
+ * Represents a Firestore Bytes value as a plain marker object.
+ *
+ * @since 8.3.0
+ */
+export interface FirestoreBytes {
+  /**
+   * @since 8.3.0
+   */
+  __type__: 'bytes';
+  /**
+   * The base64-encoded bytes value.
+   *
+   * @since 8.3.0
+   */
+  bytes: string;
+}
+
+/**
+ * Represents a special numeric value (`NaN`, `Infinity`, or `-Infinity`) as
+ * a plain marker object, since these values are not JSON-serializable and
+ * cannot be transferred over the Capacitor bridge as regular numbers.
+ *
+ * @since 8.3.0
+ */
+export interface FirestoreNumber {
+  /**
+   * @since 8.3.0
+   */
+  __type__: 'number';
+  /**
+   * The string representation of the special numeric value.
+   *
+   * @since 8.3.0
+   */
+  value: 'NaN' | 'Infinity' | '-Infinity';
 }
 
 /**

--- a/packages/firestore/src/definitions.ts
+++ b/packages/firestore/src/definitions.ts
@@ -457,7 +457,8 @@ export interface SnapshotListenerOptions {
 /**
  * @since 5.2.0
  */
-export interface AddDocumentSnapshotListenerOptions extends SnapshotListenerOptions {
+export interface AddDocumentSnapshotListenerOptions
+  extends SnapshotListenerOptions {
   /**
    * The reference as a string, with path components separated by a forward slash (`/`).
    *
@@ -482,7 +483,8 @@ export type AddDocumentSnapshotListenerCallbackEvent<T> = GetDocumentResult<T>;
 /**
  * @since 5.2.0
  */
-export interface AddCollectionSnapshotListenerOptions extends SnapshotListenerOptions {
+export interface AddCollectionSnapshotListenerOptions
+  extends SnapshotListenerOptions {
   /**
    * The reference as a string, with path components separated by a forward slash (`/`).
    *
@@ -520,7 +522,8 @@ export type AddCollectionSnapshotListenerCallbackEvent<T> =
 /**
  * @since 6.1.0
  */
-export interface AddCollectionGroupSnapshotListenerOptions extends SnapshotListenerOptions {
+export interface AddCollectionGroupSnapshotListenerOptions
+  extends SnapshotListenerOptions {
   /**
    * The reference as a string, with path components separated by a forward slash (`/`).
    *

--- a/packages/firestore/src/index.ts
+++ b/packages/firestore/src/index.ts
@@ -13,6 +13,7 @@ const FirebaseFirestore = new FirebaseFirestoreClient(
 
 export * from './definitions';
 export { FirebaseFirestore };
+export { Bytes } from './bytes';
 export { FieldValue } from './field-value';
 export { GeoPoint } from './geopoint';
 export { Timestamp } from './timestamp';

--- a/packages/firestore/src/special-number.ts
+++ b/packages/firestore/src/special-number.ts
@@ -1,0 +1,24 @@
+import type { FirestoreNumber } from './definitions';
+
+export function serializeSpecialNumber(value: number): FirestoreNumber {
+  if (Number.isNaN(value)) {
+    return { __type__: 'number', value: 'NaN' };
+  }
+  if (value === Infinity) {
+    return { __type__: 'number', value: 'Infinity' };
+  }
+  return { __type__: 'number', value: '-Infinity' };
+}
+
+export function deserializeSpecialNumber(value: string): number {
+  if (value === 'NaN') {
+    return NaN;
+  }
+  if (value === 'Infinity') {
+    return Infinity;
+  }
+  if (value === '-Infinity') {
+    return -Infinity;
+  }
+  return Number(value);
+}

--- a/packages/firestore/src/utils.ts
+++ b/packages/firestore/src/utils.ts
@@ -1,6 +1,10 @@
 import { Bytes } from './bytes';
 import { FieldValue } from './field-value';
 import { GeoPoint } from './geopoint';
+import {
+  deserializeSpecialNumber,
+  serializeSpecialNumber,
+} from './special-number';
 import { Timestamp } from './timestamp';
 
 export function serializeData(data: any): any {
@@ -58,30 +62,4 @@ export function deserializeData(data: any): any {
     return result;
   }
   return data;
-}
-
-function serializeSpecialNumber(value: number): {
-  __type__: 'number';
-  value: 'NaN' | 'Infinity' | '-Infinity';
-} {
-  if (Number.isNaN(value)) {
-    return { __type__: 'number', value: 'NaN' };
-  }
-  if (value === Infinity) {
-    return { __type__: 'number', value: 'Infinity' };
-  }
-  return { __type__: 'number', value: '-Infinity' };
-}
-
-function deserializeSpecialNumber(value: string): number {
-  if (value === 'NaN') {
-    return NaN;
-  }
-  if (value === 'Infinity') {
-    return Infinity;
-  }
-  if (value === '-Infinity') {
-    return -Infinity;
-  }
-  return Number(value);
 }

--- a/packages/firestore/src/utils.ts
+++ b/packages/firestore/src/utils.ts
@@ -1,3 +1,4 @@
+import { Bytes } from './bytes';
 import { FieldValue } from './field-value';
 import { GeoPoint } from './geopoint';
 import { Timestamp } from './timestamp';
@@ -6,9 +7,13 @@ export function serializeData(data: any): any {
   if (data === null || data === undefined) {
     return data;
   }
+  if (typeof data === 'number' && !Number.isFinite(data)) {
+    return serializeSpecialNumber(data);
+  }
   if (
     data instanceof Timestamp ||
     data instanceof GeoPoint ||
+    data instanceof Bytes ||
     data instanceof FieldValue
   ) {
     return data.toJSON();
@@ -40,6 +45,12 @@ export function deserializeData(data: any): any {
     if (data.__type__ === 'geopoint') {
       return new GeoPoint(data.latitude, data.longitude);
     }
+    if (data.__type__ === 'bytes') {
+      return Bytes.fromBase64String(data.bytes);
+    }
+    if (data.__type__ === 'number') {
+      return deserializeSpecialNumber(data.value);
+    }
     const result: Record<string, any> = {};
     for (const key of Object.keys(data)) {
       result[key] = deserializeData(data[key]);
@@ -47,4 +58,30 @@ export function deserializeData(data: any): any {
     return result;
   }
   return data;
+}
+
+function serializeSpecialNumber(value: number): {
+  __type__: 'number';
+  value: 'NaN' | 'Infinity' | '-Infinity';
+} {
+  if (Number.isNaN(value)) {
+    return { __type__: 'number', value: 'NaN' };
+  }
+  if (value === Infinity) {
+    return { __type__: 'number', value: 'Infinity' };
+  }
+  return { __type__: 'number', value: '-Infinity' };
+}
+
+function deserializeSpecialNumber(value: string): number {
+  if (value === 'NaN') {
+    return NaN;
+  }
+  if (value === 'Infinity') {
+    return Infinity;
+  }
+  if (value === '-Infinity') {
+    return -Infinity;
+  }
+  return Number(value);
 }

--- a/packages/firestore/src/web.ts
+++ b/packages/firestore/src/web.ts
@@ -91,6 +91,10 @@ import type {
 } from './definitions';
 import { FieldValue } from './field-value';
 import { GeoPoint } from './geopoint';
+import {
+  deserializeSpecialNumber,
+  serializeSpecialNumber,
+} from './special-number';
 import { Timestamp } from './timestamp';
 
 export class FirebaseFirestoreWeb
@@ -603,7 +607,7 @@ export class FirebaseFirestoreWeb
       };
     }
     if (typeof data === 'number' && !Number.isFinite(data)) {
-      return this.serializeSpecialNumber(data);
+      return serializeSpecialNumber(data);
     }
     if (Array.isArray(data)) {
       return data.map(item => this.deserializeData(item));
@@ -669,7 +673,7 @@ export class FirebaseFirestoreWeb
       case 'bytes':
         return FirebaseBytes.fromBase64String(marker.bytes);
       case 'number':
-        return this.deserializeSpecialNumber(marker.value);
+        return deserializeSpecialNumber(marker.value);
       case 'serverTimestamp':
         return serverTimestamp();
       case 'arrayUnion':
@@ -687,31 +691,5 @@ export class FirebaseFirestoreWeb
       default:
         return marker;
     }
-  }
-
-  private serializeSpecialNumber(value: number): {
-    __type__: 'number';
-    value: 'NaN' | 'Infinity' | '-Infinity';
-  } {
-    if (Number.isNaN(value)) {
-      return { __type__: 'number', value: 'NaN' };
-    }
-    if (value === Infinity) {
-      return { __type__: 'number', value: 'Infinity' };
-    }
-    return { __type__: 'number', value: '-Infinity' };
-  }
-
-  private deserializeSpecialNumber(value: string): number {
-    if (value === 'NaN') {
-      return NaN;
-    }
-    if (value === 'Infinity') {
-      return Infinity;
-    }
-    if (value === '-Infinity') {
-      return -Infinity;
-    }
-    return Number(value);
   }
 }

--- a/packages/firestore/src/web.ts
+++ b/packages/firestore/src/web.ts
@@ -10,6 +10,7 @@ import type {
   Unsubscribe,
 } from 'firebase/firestore';
 import {
+  Bytes as FirebaseBytes,
   DocumentReference as FirebaseDocumentReference,
   GeoPoint as FirebaseGeoPoint,
   Timestamp as FirebaseTimestamp,
@@ -53,6 +54,7 @@ import {
   writeBatch,
 } from 'firebase/firestore';
 
+import { Bytes } from './bytes';
 import type {
   AddCollectionGroupSnapshotListenerCallback,
   AddCollectionGroupSnapshotListenerOptions,
@@ -594,6 +596,15 @@ export class FirebaseFirestoreWeb
         path: data.path,
       };
     }
+    if (data instanceof FirebaseBytes) {
+      return {
+        __type__: 'bytes',
+        bytes: data.toBase64(),
+      };
+    }
+    if (typeof data === 'number' && !Number.isFinite(data)) {
+      return this.serializeSpecialNumber(data);
+    }
     if (Array.isArray(data)) {
       return data.map(item => this.deserializeData(item));
     }
@@ -613,6 +624,9 @@ export class FirebaseFirestoreWeb
     }
     if (data instanceof GeoPoint) {
       return new FirebaseGeoPoint(data.latitude, data.longitude);
+    }
+    if (data instanceof Bytes) {
+      return FirebaseBytes.fromBase64String(data.toBase64());
     }
     if (data instanceof FieldValue) {
       return this.serializeFieldValue(data.toJSON());
@@ -652,6 +666,10 @@ export class FirebaseFirestoreWeb
         return new FirebaseGeoPoint(marker.latitude, marker.longitude);
       case 'documentReference':
         return doc(getFirestore(), marker.path);
+      case 'bytes':
+        return FirebaseBytes.fromBase64String(marker.bytes);
+      case 'number':
+        return this.deserializeSpecialNumber(marker.value);
       case 'serverTimestamp':
         return serverTimestamp();
       case 'arrayUnion':
@@ -669,5 +687,31 @@ export class FirebaseFirestoreWeb
       default:
         return marker;
     }
+  }
+
+  private serializeSpecialNumber(value: number): {
+    __type__: 'number';
+    value: 'NaN' | 'Infinity' | '-Infinity';
+  } {
+    if (Number.isNaN(value)) {
+      return { __type__: 'number', value: 'NaN' };
+    }
+    if (value === Infinity) {
+      return { __type__: 'number', value: 'Infinity' };
+    }
+    return { __type__: 'number', value: '-Infinity' };
+  }
+
+  private deserializeSpecialNumber(value: string): number {
+    if (value === 'NaN') {
+      return NaN;
+    }
+    if (value === 'Infinity') {
+      return Infinity;
+    }
+    if (value === '-Infinity') {
+      return -Infinity;
+    }
+    return Number(value);
   }
 }


### PR DESCRIPTION
## Summary

Adds cross-platform support for additional Firestore data types previously unsupported or inconsistently handled across platforms:

- **`DocumentReference`** — full round-trip support on Android and iOS (Web was already fixed in #981).
- **`Bytes`** — new `Bytes` TS class (`fromBase64String` / `fromUint8Array` / `toBase64` / `toUint8Array`); decoded to `Blob` on Android and `Data` on iOS.
- **`NaN` / `Infinity` / `-Infinity`** — wrapped in a `{ __type__: 'number', value: 'NaN' | 'Infinity' | '-Infinity' }` marker so they survive the Capacitor bridge (which otherwise collapses them to `null`).

All three travel via the existing `__type__` marker convention used for `Timestamp`, `GeoPoint`, and `FieldValue`.

Threads the `FirebaseFirestore` instance through Android/iOS option/operation/filter constructors so `documentReference` markers can be resolved via the configured `databaseId`.

Closes #983

## Test plan

- [ ] Round-trip a document with `DocumentReference` field on Android and iOS.
- [ ] Round-trip a document with `Bytes` field on all three platforms.
- [ ] Round-trip a document with `NaN`, `Infinity`, `-Infinity` numeric fields on all three platforms.
- [ ] Verify `arrayUnion` / `arrayRemove` with nested `DocumentReference` / `Bytes` markers still serializes correctly.
- [ ] Verify filter queries with `DocumentReference` value still work (e.g. `where('owner', '==', ref)`).