### PR TITLE
fix(firestore): handle `limitToLast` query constraint on Android

### DIFF
--- a/.changeset/firestore-android-limit-to-last.md
+++ b/.changeset/firestore-android-limit-to-last.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/firestore': patch
+---
+
+fix(firestore): handle `limitToLast` query constraint on Android

--- a/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestoreHelper.java
+++ b/packages/firestore/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/firestore/FirebaseFirestoreHelper.java
@@ -102,6 +102,7 @@ public class FirebaseFirestoreHelper {
                         queryNonFilterConstraint[i] = new QueryOrderByConstraint(queryConstraint);
                         break;
                     case "limit":
+                    case "limitToLast":
                         queryNonFilterConstraint[i] = new QueryLimitConstraint(queryConstraint);
                         break;
                     case "startAt":


### PR DESCRIPTION
## Summary

`FirebaseFirestoreHelper.createQueryNonFilterConstraintArrayFromJSArray` only matched `"limit"` in its switch, so JS-sent `{ type: 'limitToLast', limit: n }` constraints were left as `null` and triggered a `NullPointerException` when callers invoked `toQuery(...)`. iOS already routes both types into `QueryLimitConstraint`; this aligns Android with that behavior.

Closes #990