### PR TITLE
feat(firestore): add `DocumentReference` class for reading and writing document reference fields

### DIFF
--- a/packages/firestore/README.md
+++ b/packages/firestore/README.md
@@ -789,17 +789,9 @@ Execute multiple write operations as a single batch.
 
 #### AddDocumentResult
 
-| Prop            | Type                                                            | Description                                | Since |
-| --------------- | --------------------------------------------------------------- | ------------------------------------------ | ----- |
-| **`reference`** | <code><a href="#documentreference">DocumentReference</a></code> | The reference of the newly added document. | 5.2.0 |
-
-
-#### DocumentReference
-
-| Prop       | Type                | Description                                      | Since |
-| ---------- | ------------------- | ------------------------------------------------ | ----- |
-| **`id`**   | <code>string</code> | The document's identifier within its collection. | 5.2.0 |
-| **`path`** | <code>string</code> | The path of the document.                        | 5.2.0 |
+| Prop            | Type                           | Description                                | Since |
+| --------------- | ------------------------------ | ------------------------------------------ | ----- |
+| **`reference`** | <code>DocumentReference</code> | The reference of the newly added document. | 5.2.0 |
 
 
 #### AddDocumentOptions

--- a/packages/firestore/src/client.ts
+++ b/packages/firestore/src/client.ts
@@ -26,6 +26,7 @@ import type {
   UseEmulatorOptions,
   WriteBatchOptions,
 } from './definitions';
+import { DocumentReference } from './document-reference';
 import { deserializeData, serializeData } from './utils';
 
 export class FirebaseFirestoreClient implements FirebaseFirestorePlugin {
@@ -76,10 +77,12 @@ export class FirebaseFirestoreClient implements FirebaseFirestorePlugin {
   }
 
   async addDocument(options: AddDocumentOptions): Promise<AddDocumentResult> {
-    return this.plugin.addDocument({
+    const result = await this.plugin.addDocument({
       ...options,
       data: serializeData(options.data),
     });
+    result.reference = DocumentReference.fromPath(result.reference.path);
+    return result;
   }
 
   async addDocumentSnapshotListener<T extends DocumentData = DocumentData>(

--- a/packages/firestore/src/definitions.ts
+++ b/packages/firestore/src/definitions.ts
@@ -1,5 +1,7 @@
 /// <reference types="@capacitor/cli" />
 
+import type { DocumentReference } from './document-reference';
+
 declare module '@capacitor/cli' {
   export interface PluginsConfig {
     /**
@@ -621,26 +623,6 @@ export interface GetCountFromServerResult {
    * @since 6.4.0
    */
   count: number;
-}
-
-/**
- * @since 5.2.0
- */
-export interface DocumentReference {
-  /**
-   * The document's identifier within its collection.
-   *
-   * @since 5.2.0
-   * @example 'Aorq09lkt1ynbR7xhTUx'
-   */
-  id: string;
-  /**
-   * The path of the document.
-   *
-   * @since 5.2.0
-   * @example 'users/Aorq09lkt1ynbR7xhTUx'
-   */
-  path: string;
 }
 
 /**

--- a/packages/firestore/src/document-reference.ts
+++ b/packages/firestore/src/document-reference.ts
@@ -3,6 +3,7 @@ export class DocumentReference {
   readonly path: string;
 
   private constructor(path: string) {
+    DocumentReference.validatePath(path);
     this.path = path;
     this.id = path.substring(path.lastIndexOf('/') + 1);
   }
@@ -17,5 +18,15 @@ export class DocumentReference {
       id: this.id,
       path: this.path,
     };
+  }
+
+  private static validatePath(path: string): void {
+    const segments = path.split('/');
+    const hasEmptySegment = segments.some(segment => segment.length === 0);
+    if (segments.length % 2 !== 0 || hasEmptySegment) {
+      throw new Error(
+        `Invalid document reference. Document references must point to a document with an even number of non-empty path segments, but got '${path}'.`,
+      );
+    }
   }
 }

--- a/packages/firestore/src/document-reference.ts
+++ b/packages/firestore/src/document-reference.ts
@@ -1,0 +1,21 @@
+export class DocumentReference {
+  readonly id: string;
+  readonly path: string;
+
+  private constructor(path: string) {
+    this.path = path;
+    this.id = path.substring(path.lastIndexOf('/') + 1);
+  }
+
+  static fromPath(path: string): DocumentReference {
+    return new DocumentReference(path);
+  }
+
+  toJSON(): { __type__: 'documentReference'; id: string; path: string } {
+    return {
+      __type__: 'documentReference',
+      id: this.id,
+      path: this.path,
+    };
+  }
+}

--- a/packages/firestore/src/index.ts
+++ b/packages/firestore/src/index.ts
@@ -14,6 +14,7 @@ const FirebaseFirestore = new FirebaseFirestoreClient(
 export * from './definitions';
 export { FirebaseFirestore };
 export { Bytes } from './bytes';
+export { DocumentReference } from './document-reference';
 export { FieldValue } from './field-value';
 export { GeoPoint } from './geopoint';
 export { Timestamp } from './timestamp';

--- a/packages/firestore/src/utils.ts
+++ b/packages/firestore/src/utils.ts
@@ -1,4 +1,5 @@
 import { Bytes } from './bytes';
+import { DocumentReference } from './document-reference';
 import { FieldValue } from './field-value';
 import { GeoPoint } from './geopoint';
 import {
@@ -18,6 +19,7 @@ export function serializeData(data: any): any {
     data instanceof Timestamp ||
     data instanceof GeoPoint ||
     data instanceof Bytes ||
+    data instanceof DocumentReference ||
     data instanceof FieldValue
   ) {
     return data.toJSON();
@@ -51,6 +53,9 @@ export function deserializeData(data: any): any {
     }
     if (data.__type__ === 'bytes') {
       return Bytes.fromBase64String(data.bytes);
+    }
+    if (data.__type__ === 'documentReference') {
+      return DocumentReference.fromPath(data.path);
     }
     if (data.__type__ === 'number') {
       return deserializeSpecialNumber(data.value);

--- a/packages/firestore/src/web.ts
+++ b/packages/firestore/src/web.ts
@@ -89,6 +89,7 @@ import type {
   UseEmulatorOptions,
   WriteBatchOptions,
 } from './definitions';
+import { DocumentReference } from './document-reference';
 import { FieldValue } from './field-value';
 import { GeoPoint } from './geopoint';
 import {
@@ -206,10 +207,7 @@ export class FirebaseFirestoreWeb
       this.serializeData(data),
     );
     return {
-      reference: {
-        id: documentReference.id,
-        path: documentReference.path,
-      },
+      reference: DocumentReference.fromPath(documentReference.path),
     };
   }
 


### PR DESCRIPTION
## Description

Adds a dedicated `DocumentReference` class to the `firestore` package, bringing it in line with the other special Firestore data types (`Timestamp`, `GeoPoint`, `Bytes`), which already have dedicated classes. Previously, `DocumentReference` was only a plain interface, which made document reference fields awkward to work with.

### What changed

- **New `DocumentReference` class** with a `fromPath()` factory, `readonly` `id` and `path` properties, and a `toJSON()` serializer. The constructor is private, mirroring the `Bytes` class (the Firebase JS SDK also hides the `DocumentReference` constructor).
- **Reading reference fields** now returns a `DocumentReference` instance instead of leaking the internal `{ __type__, id, path }` marker object to consumers.
- **Writing reference fields** is now ergonomic — pass a `DocumentReference` instance directly into document data.
- **`addDocument`** now returns a `DocumentReference` instance, so the returned reference can be written straight into another document's field.

No native changes were required; the wire format is unchanged, so Android and iOS already produce and consume it.

### Example

```typescript
const { reference } = await FirebaseFirestore.addDocument({
  reference: 'users',
  data: { first: 'Alan' },
});
await FirebaseFirestore.setDocument({
  reference: 'posts/1',
  data: { author: reference },
});
```

## Verification

- `npm run verify:web` builds successfully.
- `npm run eslint` and `npm run prettier -- --check` pass.