### PR TITLE
docs: update capawesome.io links to new URL structure

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -85,7 +85,7 @@ body:
         A well-written bug report allows the maintainers to quickly recreate the necessary conditions to inspect the bug and quickly find its root cause.
         Please ensure your bug report fulfills all of the following requirements.
       options:
-      - label: I have read and followed the [bug report guidelines](https://capawesome.io/contributing/bug-reports/).
+      - label: I have read and followed the [bug report guidelines](https://capawesome.io/docs/contributing/bug-reports/).
         required: true
       - label: I have attached links to possibly related issues and discussions.
         required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -47,7 +47,7 @@ body:
       description: |
         Please ensure your idea fulfills all of the following requirements.
       options:
-      - label: I have read and followed the [feature request guidelines](https://capawesome.io/contributing/feature-requests/).
+      - label: I have read and followed the [feature request guidelines](https://capawesome.io/docs/contributing/feature-requests/).
         required: true
       - label: I have attached links to possibly related issues and discussions.
         required: true

--- a/.github/ISSUE_TEMPLATE/plugin_request.yml
+++ b/.github/ISSUE_TEMPLATE/plugin_request.yml
@@ -35,7 +35,7 @@ body:
       description: |
         Please ensure your idea fulfills all of the following requirements.
       options:
-      - label: I have read and followed the [plugin request guidelines](https://capawesome.io/contributing/plugin-requests/).
+      - label: I have read and followed the [plugin request guidelines](https://capawesome.io/docs/contributing/plugin-requests/).
         required: true
       - label: I have attached links to possibly related issues and discussions.
         required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,4 +4,4 @@ Please check if your PR fulfills the following requirements:
 
 - [ ] The changes have been tested successfully.
 - [ ] A changeset has been created (`npm run changeset`).
-- [ ] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).
+- [ ] I have read and followed the [pull request guidelines](https://capawesome.io/docs/contributing/pull-requests/).


### PR DESCRIPTION
## Summary

The capawesome.io documentation moved to a new URL structure. This PR updates the affected links in the issue and pull request templates:

- `capawesome.io/contributing/...` → `capawesome.io/docs/contributing/...`

All new URLs were verified to resolve successfully.