### PR TITLE
docs: use human-readable plugin names as README headings

### DIFF
--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -1,4 +1,4 @@
-# @capacitor-firebase/analytics
+# Capacitor Firebase Analytics Plugin
 
 Unofficial Capacitor plugin for [Firebase Analytics](https://firebase.google.com/docs/analytics).[^1]
 

--- a/packages/app-check/README.md
+++ b/packages/app-check/README.md
@@ -1,4 +1,4 @@
-# @capacitor-firebase/app-check
+# Capacitor Firebase App Check Plugin
 
 Unofficial Capacitor plugin for [Firebase App Check](https://firebase.google.com/docs/app-check).[^1]
 

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -1,4 +1,4 @@
-# @capacitor-firebase/app
+# Capacitor Firebase App Plugin
 
 Unofficial Capacitor plugin for [Firebase App](https://firebase.google.com/docs).[^1]
 

--- a/packages/authentication/README.md
+++ b/packages/authentication/README.md
@@ -1,4 +1,4 @@
-# @capacitor-firebase/authentication
+# Capacitor Firebase Authentication Plugin
 
 Unofficial Capacitor plugin for [Firebase Authentication](https://firebase.google.com/docs/auth).[^1]
 

--- a/packages/crashlytics/README.md
+++ b/packages/crashlytics/README.md
@@ -1,4 +1,4 @@
-# @capacitor-firebase/crashlytics
+# Capacitor Firebase Crashlytics Plugin
 
 Unofficial Capacitor plugin for [Firebase Crashlytics](https://firebase.google.com/docs/crashlytics/).[^1]
 

--- a/packages/firestore/README.md
+++ b/packages/firestore/README.md
@@ -1,4 +1,4 @@
-# @capacitor-firebase/firestore
+# Capacitor Firebase Cloud Firestore Plugin
 
 Unofficial Capacitor plugin for [Firebase Cloud Firestore](https://firebase.google.com/docs/firestore/).[^1]
 

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -1,4 +1,4 @@
-# @capacitor-firebase/functions
+# Capacitor Firebase Cloud Functions Plugin
 
 Unofficial Capacitor plugin for [Firebase Cloud Functions](https://firebase.google.com/docs/functions/).[^1]
 

--- a/packages/messaging/README.md
+++ b/packages/messaging/README.md
@@ -1,4 +1,4 @@
-# @capacitor-firebase/messaging
+# Capacitor Firebase Cloud Messaging Plugin
 
 Unofficial Capacitor plugin for [Firebase Cloud Messaging](https://firebase.google.com/docs/cloud-messaging).[^1]
 

--- a/packages/performance/README.md
+++ b/packages/performance/README.md
@@ -1,4 +1,4 @@
-# @capacitor-firebase/performance
+# Capacitor Firebase Performance Monitoring Plugin
 
 Unofficial Capacitor plugin for [Firebase Performance Monitoring](https://firebase.google.com/docs/perf-mon).[^1]
 

--- a/packages/remote-config/README.md
+++ b/packages/remote-config/README.md
@@ -1,4 +1,4 @@
-# @capacitor-firebase/remote-config
+# Capacitor Firebase Remote Config Plugin
 
 Unofficial Capacitor plugin for [Firebase Remote Config](https://firebase.google.com/docs/remote-config).[^1]
 

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -1,4 +1,4 @@
-# @capacitor-firebase/storage
+# Capacitor Firebase Cloud Storage Plugin
 
 Unofficial Capacitor plugin for [Firebase Cloud Storage](https://firebase.google.com/docs/storage/).[^1]
 


### PR DESCRIPTION
## Summary

Renames each plugin README's h1 from the npm package name (e.g. `@capacitor-firebase/authentication`) to the human-readable plugin name with a `Plugin` suffix (e.g. "Capacitor Firebase Authentication Plugin").

The names follow the Firebase product names used in the capawesome.io navigation (e.g. "Cloud Firestore", "Cloud Messaging", "Performance Monitoring").