### PR TITLE
fix: update CocoaPods dependency constraints in podspec files to allow minor updates

### DIFF
--- a/.changeset/quiet-jokes-attack.md
+++ b/.changeset/quiet-jokes-attack.md
@@ -1,0 +1,15 @@
+---
+'@capacitor-firebase/authentication': patch
+'@capacitor-firebase/remote-config': patch
+'@capacitor-firebase/crashlytics': patch
+'@capacitor-firebase/performance': patch
+'@capacitor-firebase/analytics': patch
+'@capacitor-firebase/app-check': patch
+'@capacitor-firebase/firestore': patch
+'@capacitor-firebase/functions': patch
+'@capacitor-firebase/messaging': patch
+'@capacitor-firebase/storage': patch
+'@capacitor-firebase/app': patch
+---
+
+fix: update CocoaPods dependency constraints in the podspec files to allow minor updates

--- a/packages/analytics/CapacitorFirebaseAnalytics.podspec
+++ b/packages/analytics/CapacitorFirebaseAnalytics.podspec
@@ -22,11 +22,11 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'Analytics' do |analytics|
-    analytics.dependency 'FirebaseAnalytics/Core', '~> 12.7.0'
-    analytics.dependency 'FirebaseAnalytics/IdentitySupport', '~> 12.7.0'
+    analytics.dependency 'FirebaseAnalytics/Core', '~> 12.7'
+    analytics.dependency 'FirebaseAnalytics/IdentitySupport', '~> 12.7'
   end
 
   s.subspec 'AnalyticsWithoutAdIdSupport' do |analyticsWithoutAdIdSupport|
-    analyticsWithoutAdIdSupport.dependency 'FirebaseAnalytics/Core', '~> 12.7.0'
+    analyticsWithoutAdIdSupport.dependency 'FirebaseAnalytics/Core', '~> 12.7'
   end
 end

--- a/packages/app-check/CapacitorFirebaseAppCheck.podspec
+++ b/packages/app-check/CapacitorFirebaseAppCheck.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
-  s.dependency 'FirebaseAppCheck', '~> 12.7.0'
+  s.dependency 'FirebaseAppCheck', '~> 12.7'
   s.swift_version = '5.1'
   s.static_framework = true
 end

--- a/packages/app/CapacitorFirebaseApp.podspec
+++ b/packages/app/CapacitorFirebaseApp.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
-  s.dependency 'FirebaseCore', '~> 12.7.0'
+  s.dependency 'FirebaseCore', '~> 12.7'
   s.swift_version = '5.1'
   s.static_framework = true
 end

--- a/packages/authentication/CapacitorFirebaseAuthentication.podspec
+++ b/packages/authentication/CapacitorFirebaseAuthentication.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
-  s.dependency 'FirebaseAuth', '~> 12.7.0'
+  s.dependency 'FirebaseAuth', '~> 12.7'
   s.swift_version = '5.1'
   s.static_framework = true
   s.default_subspec = 'Lite'
@@ -24,12 +24,12 @@ Pod::Spec.new do |s|
 
   s.subspec 'Google' do |google|
     google.xcconfig = { 'OTHER_SWIFT_FLAGS' => '$(inherited) -DRGCFA_INCLUDE_GOOGLE' }
-    google.dependency 'GoogleSignIn', '9.0.0'
+    google.dependency 'GoogleSignIn', '~> 9.0'
   end
 
   s.subspec 'Facebook' do |facebook|
     facebook.xcconfig = { 'OTHER_SWIFT_FLAGS' => '$(inherited) -DRGCFA_INCLUDE_FACEBOOK' }
-    facebook.dependency 'FBSDKCoreKit', '18.0.0'
-    facebook.dependency 'FBSDKLoginKit', '18.0.0'
+    facebook.dependency 'FBSDKCoreKit', '~> 18.0'
+    facebook.dependency 'FBSDKLoginKit', '~> 18.0'
   end
 end

--- a/packages/authentication/ios/Podfile
+++ b/packages/authentication/ios/Podfile
@@ -10,7 +10,7 @@ end
 target 'Plugin' do
   capacitor_pods
   pod 'FirebaseAuth', '~> 12.7'
-  pod 'GoogleSignIn', '~> 7.1'
+  pod 'GoogleSignIn', '~> 9.0'
   pod 'FBSDKCoreKit', '~> 18.0'
   pod 'FBSDKLoginKit', '~> 18.0'
 end

--- a/packages/crashlytics/CapacitorFirebaseCrashlytics.podspec
+++ b/packages/crashlytics/CapacitorFirebaseCrashlytics.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
-  s.dependency 'FirebaseCrashlytics', '~> 12.7.0'
+  s.dependency 'FirebaseCrashlytics', '~> 12.7'
   s.swift_version = '5.1'
   s.static_framework = true
 end

--- a/packages/firestore/CapacitorFirebaseFirestore.podspec
+++ b/packages/firestore/CapacitorFirebaseFirestore.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
-  s.dependency 'FirebaseFirestore', '~> 12.7.0'
+  s.dependency 'FirebaseFirestore', '~> 12.7'
   s.swift_version = '5.1'
   s.static_framework = true
 end

--- a/packages/functions/CapacitorFirebaseFunctions.podspec
+++ b/packages/functions/CapacitorFirebaseFunctions.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
-  s.dependency 'FirebaseFunctions', '~> 12.7.0'
+  s.dependency 'FirebaseFunctions', '~> 12.7'
   s.swift_version = '5.1'
   s.static_framework = true
 end

--- a/packages/messaging/CapacitorFirebaseMessaging.podspec
+++ b/packages/messaging/CapacitorFirebaseMessaging.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
-  s.dependency 'FirebaseMessaging', '~> 12.7.0'
+  s.dependency 'FirebaseMessaging', '~> 12.7'
   s.swift_version = '5.1'
   s.static_framework = true
 end

--- a/packages/performance/CapacitorFirebasePerformance.podspec
+++ b/packages/performance/CapacitorFirebasePerformance.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
-  s.dependency 'FirebasePerformance', '~> 12.7.0'
+  s.dependency 'FirebasePerformance', '~> 12.7'
   s.swift_version = '5.1'
   s.static_framework = true
 end

--- a/packages/remote-config/CapacitorFirebaseRemoteConfig.podspec
+++ b/packages/remote-config/CapacitorFirebaseRemoteConfig.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
-  s.dependency 'FirebaseRemoteConfig', '~> 12.7.0'
+  s.dependency 'FirebaseRemoteConfig', '~> 12.7'
   s.swift_version = '5.1'
   s.static_framework = true
 end

--- a/packages/storage/CapacitorFirebaseStorage.podspec
+++ b/packages/storage/CapacitorFirebaseStorage.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
-  s.dependency 'FirebaseStorage', '~> 12.7.0'
+  s.dependency 'FirebaseStorage', '~> 12.7'
   s.swift_version = '5.1'
   s.static_framework = true
 end


### PR DESCRIPTION
The podspec files restricted the Firebase dependencies to `~> 12.7.0`, which in CocoaPods only permits patch updates (`>= 12.7.0, < 12.8.0`). As a result, consumers were unable to install newer Firebase releases such as 12.17.0 without waiting for a new plugin release.

This was inconsistent with the rest of the project:

| File | Constraint | Resolves to |
| --- | --- | --- |
| `*.podspec` | `~> 12.7.0` | `>= 12.7.0, < 12.8.0` (patch only) |
| `Package.swift` | `.upToNextMajor(from: "12.7.0")` | `>= 12.7.0, < 13.0.0` |
| `ios/Podfile` | `~> 12.7` | `>= 12.7, < 13.0` |

#910 already relaxed these constraints, but only for the `Podfile` files. The podspec files were missed and are corrected here.

## Changes

- Relax the Firebase constraints in all 11 podspec files from `~> 12.7.0` to `~> 12.7`, so minor updates are allowed.
- Relax the exact pins in `CapacitorFirebaseAuthentication.podspec` (`GoogleSignIn` `9.0.0` to `~> 9.0`, `FBSDKCoreKit` and `FBSDKLoginKit` `18.0.0` to `~> 18.0`) to match the ranges already used in `Package.swift`.
- Update `GoogleSignIn` in `packages/authentication/ios/Podfile` from `~> 7.1` to `~> 9.0`. It was two major versions behind the podspec and `Package.swift`, which both already required 9.0.0.

The Firebase version itself is intentionally not bumped. Relaxing the constraint is enough to let consumers install 12.17.0.

## Testing

`npm run verify:ios` passes for `packages/authentication`, with `GoogleSignIn` resolving to 9.2.0.

Close #1005
