### PR TITLE
feat(remote-config): add `setCustomSignals(...)` method

### DIFF
--- a/.changeset/eight-jokes-repeat.md
+++ b/.changeset/eight-jokes-repeat.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/remote-config': minor
+---
+
+feat: add `setCustomSignals(...)` method

--- a/packages/remote-config/README.md
+++ b/packages/remote-config/README.md
@@ -103,7 +103,7 @@ The following starter templates are available:
 
 ## Usage
 
-The following examples show how to fetch and activate the configuration, read configuration values, configure the fetch behavior, and listen for configuration updates in real time.
+The following examples show how to fetch and activate the configuration, read configuration values, configure the fetch behavior, set custom signals, and listen for configuration updates in real time.
 
 ### Fetch and activate the configuration
 
@@ -171,6 +171,23 @@ const setSettings = async () => {
 };
 ```
 
+### Set custom signals
+
+Set custom signals for the app instance that can be used for targeting in Remote Config conditions. Signals with a `null` value will be removed:
+
+```typescript
+import { FirebaseRemoteConfig } from '@capacitor-firebase/remote-config';
+
+const setCustomSignals = async () => {
+  await FirebaseRemoteConfig.setCustomSignals({
+    customSignals: {
+      city: 'Berlin',
+      preferred_event_category: 'concerts',
+    },
+  });
+};
+```
+
 ### Listen for configuration updates in real time
 
 Add a listener for the config update event to be notified as soon as parameter values change. Only available on Android and iOS:
@@ -223,6 +240,7 @@ const removeAllListeners = async () => {
 * [`getAll()`](#getall)
 * [`getInfo()`](#getinfo)
 * [`setMinimumFetchInterval(...)`](#setminimumfetchinterval)
+* [`setCustomSignals(...)`](#setcustomsignals)
 * [`setDefaults(...)`](#setdefaults)
 * [`setSettings(...)`](#setsettings)
 * [`addConfigUpdateListener(...)`](#addconfigupdatelistener)
@@ -386,6 +404,23 @@ Only available for Web.
 --------------------
 
 
+### setCustomSignals(...)
+
+```typescript
+setCustomSignals(options: SetCustomSignalsOptions) => Promise<void>
+```
+
+Set custom signals for the app instance that can be used for targeting in Remote Config conditions.
+
+| Param         | Type                                                                        |
+| ------------- | --------------------------------------------------------------------------- |
+| **`options`** | <code><a href="#setcustomsignalsoptions">SetCustomSignalsOptions</a></code> |
+
+**Since:** 8.4.0
+
+--------------------
+
+
 ### setDefaults(...)
 
 ```typescript
@@ -544,6 +579,13 @@ Remove all listeners for this plugin.
 | Prop                                | Type                | Description                                                                                                                                                                           | Default            | Since |
 | ----------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ----- |
 | **`minimumFetchIntervalInSeconds`** | <code>number</code> | Define the maximum age in seconds of an entry in the config cache before it is considered stale. During development, it's recommended to set a relatively low minimum fetch interval. | <code>43200</code> | 1.3.0 |
+
+
+#### SetCustomSignalsOptions
+
+| Prop                | Type                                                        | Description                                                                                  | Since |
+| ------------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ----- |
+| **`customSignals`** | <code>Record&lt;string, string \| number \| null&gt;</code> | The custom signals to set for the app instance. Signals with a `null` value will be removed. | 8.4.0 |
 
 
 #### SetDefaultsOptions

--- a/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -9,6 +9,7 @@ import com.google.android.gms.tasks.Task;
 import com.google.firebase.remoteconfig.ConfigUpdate;
 import com.google.firebase.remoteconfig.ConfigUpdateListener;
 import com.google.firebase.remoteconfig.ConfigUpdateListenerRegistration;
+import com.google.firebase.remoteconfig.CustomSignals;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigException;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigInfo;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings;
@@ -20,6 +21,7 @@ import io.capawesome.capacitorjs.plugins.firebase.remoteconfig.interfaces.NonEmp
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import org.json.JSONObject;
 
 public class FirebaseRemoteConfig {
 
@@ -91,6 +93,26 @@ public class FirebaseRemoteConfig {
         int lastFetchStatus = info.getLastFetchStatus();
 
         return new GetInfoResult(lastFetchTime, lastFetchStatus);
+    }
+
+    public Task<Void> setCustomSignals(@NonNull Map<String, Object> customSignals) {
+        CustomSignals.Builder builder = new CustomSignals.Builder();
+        for (Map.Entry<String, Object> entry : customSignals.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            if (value == null || value == JSONObject.NULL) {
+                builder.put(key, (String) null);
+            } else if (value instanceof String) {
+                builder.put(key, (String) value);
+            } else if (value instanceof Integer || value instanceof Long) {
+                builder.put(key, ((Number) value).longValue());
+            } else if (value instanceof Number) {
+                builder.put(key, ((Number) value).doubleValue());
+            } else {
+                throw new IllegalArgumentException("Unsupported value type for key: " + key);
+            }
+        }
+        return getFirebaseRemoteConfigInstance().setCustomSignals(builder.build());
     }
 
     public Task<Void> setDefaults(@NonNull Map<String, Object> defaults) {

--- a/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
+++ b/packages/remote-config/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/remoteconfig/FirebaseRemoteConfigPlugin.java
@@ -21,6 +21,7 @@ public class FirebaseRemoteConfigPlugin extends Plugin {
     public static final String TAG = "FirebaseRemoteConfig";
     public static final String ERROR_KEY_MISSING = "key must be provided.";
     public static final String ERROR_CALLBACK_ID_MISSING = "callbackId must be provided.";
+    public static final String ERROR_CUSTOM_SIGNALS_MISSING = "customSignals must be provided.";
     public static final String ERROR_DEFAULTS_MISSING = "defaults must be provided.";
 
     private static final int DEFAULT_MINIMUM_FETCH_INTERVAL_IN_SECONDS = 43200;
@@ -197,6 +198,37 @@ public class FirebaseRemoteConfigPlugin extends Plugin {
     @PluginMethod
     public void setMinimumFetchInterval(PluginCall call) {
         call.reject("Not available on Android.");
+    }
+
+    @PluginMethod
+    public void setCustomSignals(PluginCall call) {
+        try {
+            JSObject customSignals = call.getObject("customSignals");
+            if (customSignals == null) {
+                call.reject(ERROR_CUSTOM_SIGNALS_MISSING);
+                return;
+            }
+
+            Map<String, Object> parsedCustomSignals = new HashMap<>();
+            Iterator<String> keys = customSignals.keys();
+            while (keys.hasNext()) {
+                String key = keys.next();
+                parsedCustomSignals.put(key, customSignals.get(key));
+            }
+
+            implementation.setCustomSignals(parsedCustomSignals).addOnCompleteListener(t -> {
+                if (t.isSuccessful()) {
+                    call.resolve();
+                } else {
+                    Exception exception = t.getException();
+                    String errorMessage = exception != null ? exception.getMessage() : "Failed to set custom signals.";
+                    call.reject(errorMessage);
+                }
+            });
+        } catch (Exception exception) {
+            Logger.error(TAG, exception.getMessage(), exception);
+            call.reject(exception.getMessage());
+        }
     }
 
     @PluginMethod

--- a/packages/remote-config/ios/Plugin/FirebaseRemoteConfig.swift
+++ b/packages/remote-config/ios/Plugin/FirebaseRemoteConfig.swift
@@ -83,6 +83,29 @@ import Capacitor
         completion(lastFetchTimeMillis, statusInt, nil)
     }
 
+    @objc public func setCustomSignals(_ customSignals: [String: Any], completion: @escaping (Error?) -> Void) {
+        var signals = [String: CustomSignalValue?]()
+        for (key, value) in customSignals {
+            if let stringValue = value as? String {
+                signals[key] = .string(stringValue)
+            } else if let intValue = value as? Int {
+                signals[key] = .integer(intValue)
+            } else if let doubleValue = value as? Double {
+                signals[key] = .double(doubleValue)
+            } else {
+                signals.updateValue(nil, forKey: key)
+            }
+        }
+        Task {
+            do {
+                try await RemoteConfig.remoteConfig().setCustomSignals(signals)
+                completion(nil)
+            } catch {
+                completion(error)
+            }
+        }
+    }
+
     @objc public func setDefaults(_ defaults: [String: NSObject]) {
         RemoteConfig.remoteConfig().setDefaults(defaults)
     }

--- a/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.swift
+++ b/packages/remote-config/ios/Plugin/FirebaseRemoteConfigPlugin.swift
@@ -19,6 +19,7 @@ public class FirebaseRemoteConfigPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "getString", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getAll", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setMinimumFetchInterval", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setCustomSignals", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setDefaults", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setSettings", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "addConfigUpdateListener", returnType: CAPPluginReturnCallback),
@@ -28,6 +29,7 @@ public class FirebaseRemoteConfigPlugin: CAPPlugin, CAPBridgedPlugin {
     public let errorKeyMissing = "key must be provided."
     public let errorFetchAndActivatefailed = "fetchAndActivate failed."
     public let errorCallbackIdMissing = "callbackId must be provided."
+    public let errorCustomSignalsMissing = "customSignals must be provided."
     public let errorDefaultsMissing = "defaults must be provided."
 
     private let defaultMinimumFetchIntervalInSeconds: Double = 43200
@@ -122,6 +124,22 @@ public class FirebaseRemoteConfigPlugin: CAPPlugin, CAPBridgedPlugin {
 
     @objc func setMinimumFetchInterval(_ call: CAPPluginCall) {
         call.reject("Not available on iOS.")
+    }
+
+    @objc func setCustomSignals(_ call: CAPPluginCall) {
+        guard let customSignals = call.getObject("customSignals") else {
+            call.reject(errorCustomSignalsMissing)
+            return
+        }
+
+        implementation?.setCustomSignals(customSignals, completion: { error in
+            if let error = error {
+                CAPLog.print("[", self.tag, "] ", error)
+                call.reject(error.localizedDescription)
+                return
+            }
+            call.resolve()
+        })
     }
 
     @objc func setDefaults(_ call: CAPPluginCall) {

--- a/packages/remote-config/src/definitions.ts
+++ b/packages/remote-config/src/definitions.ts
@@ -59,6 +59,12 @@ export interface FirebaseRemoteConfigPlugin {
     options: SetMinimumFetchIntervalOptions,
   ): Promise<void>;
   /**
+   * Set custom signals for the app instance that can be used for targeting in Remote Config conditions.
+   *
+   * @since 8.4.0
+   */
+  setCustomSignals(options: SetCustomSignalsOptions): Promise<void>;
+  /**
    * Sets config defaults for parameter keys and values in the default namespace config.
    *
    * @since 8.3.0
@@ -241,6 +247,20 @@ export interface SetMinimumFetchIntervalOptions {
    * @see https://firebase.google.com/docs/reference/js/remote-config.remoteconfigsettings#remoteconfigsettingsminimumfetchintervalmillis
    */
   minimumFetchIntervalInSeconds: number;
+}
+
+/**
+ * @since 8.4.0
+ */
+export interface SetCustomSignalsOptions {
+  /**
+   * The custom signals to set for the app instance.
+   *
+   * Signals with a `null` value will be removed.
+   *
+   * @since 8.4.0
+   */
+  customSignals: Record<string, string | number | null>;
 }
 
 /**

--- a/packages/remote-config/src/web.ts
+++ b/packages/remote-config/src/web.ts
@@ -6,6 +6,7 @@ import {
   getAll,
   getRemoteConfig,
   getValue,
+  setCustomSignals,
 } from 'firebase/remote-config';
 import type { Value } from 'firebase/remote-config';
 
@@ -20,6 +21,7 @@ import type {
   GetOptions,
   GetStringResult,
   RemoveConfigUpdateListenerOptions,
+  SetCustomSignalsOptions,
   SetMinimumFetchIntervalOptions,
   SetDefaultsOptions,
   SetSettingsOptions,
@@ -108,6 +110,13 @@ export class FirebaseRemoteConfigWeb
     const remoteConfig = getRemoteConfig();
     remoteConfig.settings.minimumFetchIntervalMillis =
       options.minimumFetchIntervalInSeconds * 1000;
+  }
+
+  public async setCustomSignals(
+    options: SetCustomSignalsOptions,
+  ): Promise<void> {
+    const remoteConfig = getRemoteConfig();
+    await setCustomSignals(remoteConfig, options.customSignals);
   }
 
   public async setDefaults(options: SetDefaultsOptions): Promise<void> {


### PR DESCRIPTION
This PR adds a new `setCustomSignals(...)` method to the Remote Config plugin so that custom signals can be set for the app instance and used for targeting in Remote Config conditions. The method is supported on Android, iOS, and Web. Signals with a `null` value are removed.

Close #1009