### PR TITLE
feat(authentication): add SPM traits to make the provider SDKs optional

### DIFF
--- a/.changeset/lucky-moons-listen.md
+++ b/.changeset/lucky-moons-listen.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/authentication': minor
+---
+
+feat(ios): add `Google`, `Facebook` and `Lite` Swift Package Manager traits to make the GoogleSignIn and Facebook SDKs optional

--- a/.changeset/quiet-pears-return.md
+++ b/.changeset/quiet-pears-return.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/authentication': patch
+---
+
+fix(ios): reject instead of never resolving when signing in with or linking a provider whose SDK is not included in the build

--- a/packages/authentication/Package.swift
+++ b/packages/authentication/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.1
 import PackageDescription
 
 let package = Package(
@@ -8,6 +8,21 @@ let package = Package(
         .library(
             name: "CapacitorFirebaseAuthentication",
             targets: ["FirebaseAuthenticationPlugin"])
+    ],
+    traits: [
+        .default(enabledTraits: ["Google", "Facebook"]),
+        .trait(
+            name: "Lite",
+            description: "Excludes all optional third party SDKs."
+        ),
+        .trait(
+            name: "Google",
+            description: "Includes the Google Sign-In SDK."
+        ),
+        .trait(
+            name: "Facebook",
+            description: "Includes the Facebook SDK."
+        )
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
@@ -23,18 +38,22 @@ let package = Package(
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
                 .product(name: "FirebaseAuth", package: "firebase-ios-sdk"),
                 .product(name: "FirebaseCore", package: "firebase-ios-sdk"),
-                .product(name: "GoogleSignIn", package: "GoogleSignIn-iOS"),
-                .product(name: "FacebookCore", package: "facebook-ios-sdk"),
-                .product(name: "FacebookLogin", package: "facebook-ios-sdk")
+                .product(name: "GoogleSignIn", package: "GoogleSignIn-iOS",
+                         condition: .when(traits: ["Google"])),
+                .product(name: "FacebookCore", package: "facebook-ios-sdk",
+                         condition: .when(traits: ["Facebook"])),
+                .product(name: "FacebookLogin", package: "facebook-ios-sdk",
+                         condition: .when(traits: ["Facebook"]))
             ],
             path: "ios/Plugin",
             swiftSettings: [
-                .define("RGCFA_INCLUDE_GOOGLE"),
-                .define("RGCFA_INCLUDE_FACEBOOK")
+                .define("RGCFA_INCLUDE_GOOGLE", .when(traits: ["Google"])),
+                .define("RGCFA_INCLUDE_FACEBOOK", .when(traits: ["Facebook"]))
             ]),
         .testTarget(
             name: "FirebaseAuthenticationPluginTests",
             dependencies: ["FirebaseAuthenticationPlugin"],
             path: "ios/PluginTests")
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/packages/authentication/README.md
+++ b/packages/authentication/README.md
@@ -119,6 +119,46 @@ Add the following to your `capacitor.config.json` (or `capacitor.config.ts`) to 
 
 **Attention**: SPM `packageOptions` support requires Capacitor CLI **8.4.0+**.
 
+##### Package traits
+
+The GoogleSignIn and Facebook SDKs are optional and are included by default via the `Google` and `Facebook` package traits. If you do not use these providers, disable the corresponding trait so that the SDK is not linked into your app:
+
+```json
+{
+  "experimental": {
+    "ios": {
+      "spm": {
+        "swiftToolsVersion": "6.1",
+        "packageTraits": {
+          "@capacitor-firebase/authentication": ["Google"]
+        }
+      }
+    }
+  }
+}
+```
+
+Listing traits explicitly replaces the defaults, so only the traits you list are enabled. The example above keeps GoogleSignIn and excludes the Facebook SDK. Use the `Lite` trait to exclude both:
+
+```json
+{
+  "experimental": {
+    "ios": {
+      "spm": {
+        "swiftToolsVersion": "6.1",
+        "packageTraits": {
+          "@capacitor-firebase/authentication": ["Lite"]
+        }
+      }
+    }
+  }
+}
+```
+
+These traits are the Swift Package Manager equivalent of the `CapacitorFirebaseAuthentication/Google`, `CapacitorFirebaseAuthentication/Facebook` and `CapacitorFirebaseAuthentication/Lite` CocoaPods subspecs. Calling a sign-in method of a provider whose SDK is excluded rejects with an error.
+
+**Attention**: SPM trait support requires Capacitor CLI **8.3.0+** and Xcode **16.3+** (Swift 6.1+).
+
 ## Configuration
 
 <docgen-config>

--- a/packages/authentication/docs/setup-facebook.md
+++ b/packages/authentication/docs/setup-facebook.md
@@ -73,7 +73,7 @@
 
    Run [`npx cap update`](https://capacitorjs.com/docs/cli/update) to update the native plugins and dependencies.
 
-1. If you are using **Swift Package Manager** for your iOS project, the Facebook SDK dependencies are already included by default. No additional configuration is needed for the package dependencies.
+1. If you are using **Swift Package Manager** for your iOS project, no additional configuration is needed for the package dependencies. The `Facebook` package trait is enabled by default and includes the Facebook SDK dependencies. See [Package traits](https://github.com/capawesome-team/capacitor-firebase/tree/main/packages/authentication#package-traits) if you want to exclude them.
 1. On the [Facebook for Developers](https://developers.facebook.com/) site, get the App ID and an App Secret for your app.
 1. Enable Facebook Login:
    1. In the [Firebase console](https://console.firebase.google.com/), open the Auth section.

--- a/packages/authentication/docs/setup-google.md
+++ b/packages/authentication/docs/setup-google.md
@@ -34,7 +34,7 @@
 
    Run [`npx cap update`](https://capacitorjs.com/docs/cli/update) to update the native plugins and dependencies.
 
-1. If you are using **Swift Package Manager** for your iOS project, the GoogleSignIn dependencies are already included by default. No additional configuration is needed for the package dependencies.
+1. If you are using **Swift Package Manager** for your iOS project, no additional configuration is needed for the package dependencies. The `Google` package trait is enabled by default and includes the GoogleSignIn dependencies. See [Package traits](https://github.com/capawesome-team/capacitor-firebase/tree/main/packages/authentication#package-traits) if you want to exclude them.
 1. If you are using **CocoaPods** for your iOS project, add the following post install script to your `Podfile` (usually `ios/App/Podfile`) to disable code signing for bundles:
    ```ruby
    post_install do |installer|

--- a/packages/authentication/ios/Plugin/Handlers/FacebookAuthProviderHandler.swift
+++ b/packages/authentication/ios/Plugin/Handlers/FacebookAuthProviderHandler.swift
@@ -9,6 +9,7 @@ import FBSDKLoginKit
 class FacebookAuthProviderHandler: NSObject {
     let errorSignInCanceled = "Sign in canceled."
     let errorLinkCanceled = "Link canceled."
+    let errorSdkNotIncluded = "The Facebook SDK is not included in this build. Add the required CocoaPods subspec or Swift package trait."
     private var pluginImplementation: FirebaseAuthentication
     #if RGCFA_INCLUDE_FACEBOOK
     private var loginManager: LoginManager
@@ -117,6 +118,12 @@ class FacebookAuthProviderHandler: NSObject {
                     }
                 }
             }
+        }
+        #else
+        if isLink == true {
+            pluginImplementation.handleFailedLink(message: errorSdkNotIncluded, error: nil)
+        } else {
+            pluginImplementation.handleFailedSignIn(message: errorSdkNotIncluded, error: nil)
         }
         #endif
     }

--- a/packages/authentication/ios/Plugin/Handlers/GoogleAuthProviderHandler.swift
+++ b/packages/authentication/ios/Plugin/Handlers/GoogleAuthProviderHandler.swift
@@ -7,6 +7,7 @@ import GoogleSignIn
 #endif
 
 class GoogleAuthProviderHandler: NSObject {
+    let errorSdkNotIncluded = "The Google Sign-In SDK is not included in this build. Add the required CocoaPods subspec or Swift package trait."
     var pluginImplementation: FirebaseAuthentication
 
     init(_ pluginImplementation: FirebaseAuthentication) {
@@ -63,6 +64,12 @@ class GoogleAuthProviderHandler: NSObject {
                                                                      accessToken: accessToken, displayName: nil, authorizationCode: nil, serverAuthCode: serverAuthCode)
                 }
             }
+        }
+        #else
+        if isLink == true {
+            pluginImplementation.handleFailedLink(message: errorSdkNotIncluded, error: nil)
+        } else {
+            pluginImplementation.handleFailedSignIn(message: errorSdkNotIncluded, error: nil)
         }
         #endif
     }


### PR DESCRIPTION
Adds the `Google`, `Facebook` and `Lite` Swift Package Manager traits to `@capacitor-firebase/authentication`, so that the GoogleSignIn and Facebook SDKs can be excluded from an app the same way the `Lite` / `Google` / `Facebook` CocoaPods subspecs already allow. With a trait disabled, SwiftPM prunes the package entirely — the SDK is neither fetched nor linked, so its privacy manifest is no longer aggregated into the app's privacy report.

The default enabled traits stay `["Google", "Facebook"]`, so existing SPM consumers are unaffected. Aligning the SPM default with the CocoaPods `Lite` default is tracked in #1012.

Also fixes a pre-existing bug on both package managers: calling `signInWithGoogle()` / `signInWithFacebook()` (or the `linkWith…` equivalents) when the SDK was excluded left the promise permanently unresolved, because the entire method body sat inside the `#if RGCFA_INCLUDE_…` guard. These now reject with a message pointing at the required subspec or trait.

Note: SwiftPM traits require a `6.1` package manifest, which raises the SPM floor for this package to Xcode 16.3+. `@capacitor-firebase/analytics` already requires this.

Close #1011
Ref #1012
