### PR TITLE
Add and reposition Guides sections for recent blog guides

### DIFF
--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -28,6 +28,10 @@ The Firebase Analytics plugin is typically used to understand how users interact
 | 5.x.x          | 5.x.x             | Deprecated     |
 | 1.x.x          | 4.x.x             | Deprecated     |
 
+## Guides
+
+- [Track App Events with Firebase Analytics in Capacitor](https://capawesome.io/blog/capacitor-firebase-analytics-guide/): Log events, track screens, and set up audience segmentation with this plugin.
+
 ## Installation
 
 You can use our **AI-Assisted Setup** to install the plugin.

--- a/packages/authentication/README.md
+++ b/packages/authentication/README.md
@@ -28,6 +28,10 @@ The Firebase Authentication plugin is typically used to handle the entire sign-i
 | 5.x.x          | 5.x.x             | Deprecated     |
 | 1.x.x          | 4.x.x             | Deprecated     |
 
+## Guides
+
+- [Firebase Authentication in Capacitor: Setup & Best Practices](https://capawesome.io/blog/capacitor-firebase-authentication-guide/): Setup and best practices for sign-in flows with this plugin.
+
 ## Installation
 
 You can use our **AI-Assisted Setup** to install the plugin.

--- a/packages/firestore/README.md
+++ b/packages/firestore/README.md
@@ -18,10 +18,6 @@ The Cloud Firestore plugin is typically used to store and sync app data in the c
 - **Offline support**: Enable offline persistence and control network access to work with locally cached data.
 - **Atomic writes**: Perform multiple write operations as a single atomic batch with `writeBatch(...)`.
 
-## Guides
-
-- [Announcing the Capacitor Firebase Cloud Firestore Plugin](https://capawesome.io/blog/announcing-the-capacitor-firebase-cloud-firestore-plugin/)
-
 ## Compatibility
 
 | Plugin Version | Capacitor Version | Status         |
@@ -29,6 +25,12 @@ The Cloud Firestore plugin is typically used to store and sync app data in the c
 | 8.x.x          | >=8.x.x           | Active support |
 | 7.x.x          | 7.x.x             | Deprecated     |
 | 6.x.x          | 6.x.x             | Deprecated     |
+
+## Guides
+
+- [Announcing the Capacitor Firebase Cloud Firestore Plugin](https://capawesome.io/blog/announcing-the-capacitor-firebase-cloud-firestore-plugin/)
+- [Capacitor Firestore: Real-Time Data & Offline Sync](https://capawesome.io/blog/capacitor-firebase-cloud-firestore-guide/): Real-time listeners, offline persistence, and atomic writes with this plugin.
+- [How to Wrap an Angular App with Capacitor and Firebase](https://capawesome.io/blog/how-to-wrap-an-angular-app-with-capacitor-and-firebase/): Uses this plugin alongside Cloud Storage to store and sync user data.
 
 ## Installation
 

--- a/packages/messaging/README.md
+++ b/packages/messaging/README.md
@@ -18,10 +18,6 @@ The Firebase Cloud Messaging plugin is typically used to engage and re-engage us
 - **Background data sync**: Receive data push notifications in the background to keep the content of your app up to date.
 - **Notification management**: List, remove, or clear the notifications that are visible on the notifications screen.
 
-## Guides
-
-- [The Push Notifications Guide for Capacitor](https://capawesome.io/blog/capacitor-push-notifications-guide/)
-
 ## Compatibility
 
 | Plugin Version | Capacitor Version | Status         |
@@ -31,6 +27,10 @@ The Firebase Cloud Messaging plugin is typically used to engage and re-engage us
 | 6.x.x          | 6.x.x             | Deprecated     |
 | 5.x.x          | 5.x.x             | Deprecated     |
 | 1.x.x          | 4.x.x             | Deprecated     |
+
+## Guides
+
+- [The Push Notifications Guide for Capacitor](https://capawesome.io/blog/capacitor-push-notifications-guide/)
 
 ## Installation
 

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -25,6 +25,11 @@ The Firebase Cloud Storage plugin is typically used to store and serve user-gene
 | 7.x.x          | 7.x.x             | Deprecated     |
 | 6.x.x          | 6.x.x             | Deprecated     |
 
+## Guides
+
+- [Upload & Manage Files with Firebase Storage in Capacitor](https://capawesome.io/blog/capacitor-firebase-cloud-storage-guide/): Upload, download, and manage user-generated files with this plugin.
+- [How to Wrap an Angular App with Capacitor and Firebase](https://capawesome.io/blog/how-to-wrap-an-angular-app-with-capacitor-and-firebase/): Uses this plugin alongside Cloud Firestore to store and serve user-uploaded files.
+
 ## Installation
 
 You can use our **AI-Assisted Setup** to install the plugin.


### PR DESCRIPTION
## Summary

- `authentication`, `storage`, `analytics`: add a `## Guides` section (new) linking to their recently published blog guides.
- `firestore`: add the two missing guides to the existing section.
- `messaging`, `firestore`, `authentication`, `storage`, `analytics`: move `Guides` to after Compatibility, before Installation, matching the convention used across `capacitor-plugins`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)