### PR TITLE
fix(messaging): respect vibration option on Android

### DIFF
--- a/.changeset/fuzzy-cats-vibrate.md
+++ b/.changeset/fuzzy-cats-vibrate.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/messaging': patch
+---
+
+fix(android): respect the `vibration` option when creating notification channels

--- a/packages/messaging/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/messaging/FirebaseMessagingHelper.java
+++ b/packages/messaging/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/messaging/FirebaseMessagingHelper.java
@@ -97,7 +97,7 @@ public class FirebaseMessagingHelper {
         int importance = call.getInt("importance", NotificationManager.IMPORTANCE_DEFAULT);
         String description = call.getString("description", "");
         int visibility = call.getInt("visibility", NotificationCompat.VISIBILITY_PUBLIC);
-        boolean vibrate = call.getBoolean("vibrate", false);
+        boolean vibrate = call.getBoolean("vibration", false);
         boolean lights = call.getBoolean("lights", false);
         String lightColor = call.getString("lightColor", null);
         String sound = call.getString("sound", null);


### PR DESCRIPTION
## Summary

- Read the documented `vibration` option when creating Android notification channels.
- Align the Android implementation with the public `Channel` TypeScript interface and `listChannels()` result.
- Add a patch changeset for `@capacitor-firebase/messaging`.

Closes #1018

## Testing

- `npm run lint --workspace packages/messaging`
- `./gradlew clean build test` in `packages/messaging/android`

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).
