### PR TITLE
fix(authentication): use Google button flow on Android

### DIFF
--- a/.changeset/google-button-flow.md
+++ b/.changeset/google-button-flow.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/authentication': patch
+---
+
+fix(android): use the Google button flow with Credential Manager

--- a/packages/authentication/android/build.gradle
+++ b/packages/authentication/android/build.gradle
@@ -78,6 +78,7 @@ dependencies {
       compileOnly "com.facebook.android:facebook-login:$facebookLoginVersion"
     }
     testImplementation "junit:junit:$junitVersion"
+    testImplementation "com.google.android.libraries.identity.googleid:googleid:$librariesIdentityGoogleidVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
 }

--- a/packages/authentication/android/build.gradle
+++ b/packages/authentication/android/build.gradle
@@ -44,6 +44,9 @@ android {
     lintOptions {
         abortOnError = false
     }
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_21
         targetCompatibility JavaVersion.VERSION_21

--- a/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/handlers/GoogleAuthProviderHandler.java
+++ b/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/handlers/GoogleAuthProviderHandler.java
@@ -33,7 +33,7 @@ import com.google.android.gms.auth.api.signin.GoogleSignInOptions;
 import com.google.android.gms.common.api.ApiException;
 import com.google.android.gms.common.api.Scope;
 import com.google.android.gms.tasks.Task;
-import com.google.android.libraries.identity.googleid.GetGoogleIdOption;
+import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption;
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential;
 import com.google.firebase.auth.AuthCredential;
 import com.google.firebase.auth.GoogleAuthProvider;
@@ -294,19 +294,24 @@ public class GoogleAuthProviderHandler {
         }
     }
 
+    static GetSignInWithGoogleOption.Builder createSignInWithGoogleOptionBuilder(@NonNull String serverClientId) {
+        return new GetSignInWithGoogleOption.Builder(serverClientId);
+    }
+
     private void signInOrLink(final PluginCall call, final boolean isLink) {
         Boolean useCredentialManagerRaw = call.getBoolean("useCredentialManager");
         boolean useCredentialManager = (useCredentialManagerRaw != null) ? useCredentialManagerRaw : true;
 
         if (useCredentialManager) {
             Executor executor = Executors.newSingleThreadExecutor();
-            GetGoogleIdOption googleIdOption = new GetGoogleIdOption.Builder()
+            GetSignInWithGoogleOption googleSignInOption = createSignInWithGoogleOptionBuilder(
                 // Your server's client ID, not your Android client ID
-                .setServerClientId(pluginImplementation.getPlugin().getContext().getString(R.string.default_web_client_id))
-                // Show all accounts on the device (not just the accounts that have been used previously)
-                .setFilterByAuthorizedAccounts(false)
-                .build();
-            GetCredentialRequest request = new GetCredentialRequest.Builder().addCredentialOption(googleIdOption).build();
+                pluginImplementation
+                    .getPlugin()
+                    .getContext()
+                    .getString(R.string.default_web_client_id)
+            ).build();
+            GetCredentialRequest request = new GetCredentialRequest.Builder().addCredentialOption(googleSignInOption).build();
             CredentialManager credentialManager = CredentialManager.create(pluginImplementation.getPlugin().getActivity());
             credentialManager.getCredentialAsync(
                 pluginImplementation.getPlugin().getContext(),

--- a/packages/authentication/android/src/test/java/io/capawesome/capacitorjs/plugins/firebase/authentication/handlers/GoogleAuthProviderHandlerTest.java
+++ b/packages/authentication/android/src/test/java/io/capawesome/capacitorjs/plugins/firebase/authentication/handlers/GoogleAuthProviderHandlerTest.java
@@ -1,0 +1,16 @@
+package io.capawesome.capacitorjs.plugins.firebase.authentication.handlers;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption;
+import org.junit.Test;
+
+public class GoogleAuthProviderHandlerTest {
+
+    @Test
+    public void createSignInWithGoogleOptionBuilderUsesButtonFlow() {
+        GetSignInWithGoogleOption.Builder builder = GoogleAuthProviderHandler.createSignInWithGoogleOptionBuilder("server-client-id");
+
+        assertEquals(GetSignInWithGoogleOption.Builder.class, builder.getClass());
+    }
+}

--- a/packages/authentication/android/src/test/java/io/capawesome/capacitorjs/plugins/firebase/authentication/handlers/GoogleAuthProviderHandlerTest.java
+++ b/packages/authentication/android/src/test/java/io/capawesome/capacitorjs/plugins/firebase/authentication/handlers/GoogleAuthProviderHandlerTest.java
@@ -9,8 +9,10 @@ public class GoogleAuthProviderHandlerTest {
 
     @Test
     public void createSignInWithGoogleOptionBuilderUsesButtonFlow() {
-        GetSignInWithGoogleOption.Builder builder = GoogleAuthProviderHandler.createSignInWithGoogleOptionBuilder("server-client-id");
+        String serverClientId = "1234567890-abcdefg.apps.googleusercontent.com";
 
-        assertEquals(GetSignInWithGoogleOption.Builder.class, builder.getClass());
+        GetSignInWithGoogleOption option = GoogleAuthProviderHandler.createSignInWithGoogleOptionBuilder(serverClientId).build();
+
+        assertEquals(serverClientId, option.getServerClientId());
     }
 }


### PR DESCRIPTION
## Summary

- replace `GetGoogleIdOption` with the button-specific `GetSignInWithGoogleOption` for Credential Manager Google sign-in and account linking
- keep the existing credential response, scopes, and legacy opt-out paths unchanged
- add an Android regression test and a patch changeset

Closes #1020

## Testing

- `npm run verify:android --workspace=@capacitor-firebase/authentication`
- `npm run verify:web --workspace=@capacitor-firebase/authentication`
- `npm run verify:ios --workspace=@capacitor-firebase/authentication`
- `npm run lint --workspace=@capacitor-firebase/authentication`

Automated builds and tests pass. This environment does not include an Android 16 Samsung device with multiple Google accounts, so the device-specific reproduction still needs maintainer or downstream hardware validation.

## Pull request checklist

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/docs/contributing/pull-requests/).