### PR TITLE
fix(ios): remove unresolvable SPM test target from package manifests

### DIFF
--- a/.changeset/spm-test-target-path.md
+++ b/.changeset/spm-test-target-path.md
@@ -1,0 +1,15 @@
+---
+'@capacitor-firebase/analytics': patch
+'@capacitor-firebase/app': patch
+'@capacitor-firebase/app-check': patch
+'@capacitor-firebase/authentication': patch
+'@capacitor-firebase/crashlytics': patch
+'@capacitor-firebase/firestore': patch
+'@capacitor-firebase/functions': patch
+'@capacitor-firebase/messaging': patch
+'@capacitor-firebase/performance': patch
+'@capacitor-firebase/remote-config': patch
+'@capacitor-firebase/storage': patch
+---
+
+fix(ios): remove the SPM test target that made the published package unresolvable by SwiftPM

--- a/packages/analytics/Package.swift
+++ b/packages/analytics/Package.swift
@@ -36,11 +36,7 @@ let package = Package(
                          condition: .when(traits: ["AnalyticsWithoutAdIdSupport"])),
                 .product(name: "FirebaseCore", package: "firebase-ios-sdk")
             ],
-            path: "ios/Plugin"),
-        .testTarget(
-            name: "FirebaseAnalyticsPluginTests",
-            dependencies: ["FirebaseAnalyticsPlugin"],
-            path: "ios/PluginTests")
+            path: "ios/Plugin")
     ],
     swiftLanguageModes: [.v5]
 )

--- a/packages/app-check/Package.swift
+++ b/packages/app-check/Package.swift
@@ -22,10 +22,6 @@ let package = Package(
                 .product(name: "FirebaseAppCheck", package: "firebase-ios-sdk"),
                 .product(name: "FirebaseCore", package: "firebase-ios-sdk")
             ],
-            path: "ios/Plugin"),
-        .testTarget(
-            name: "FirebaseAppCheckPluginTests",
-            dependencies: ["FirebaseAppCheckPlugin"],
-            path: "ios/PluginTests")
+            path: "ios/Plugin")
     ]
 )

--- a/packages/app/Package.swift
+++ b/packages/app/Package.swift
@@ -21,10 +21,6 @@ let package = Package(
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
                 .product(name: "FirebaseCore", package: "firebase-ios-sdk")
             ],
-            path: "ios/Plugin"),
-        .testTarget(
-            name: "FirebaseAppPluginTests",
-            dependencies: ["FirebaseAppPlugin"],
-            path: "ios/PluginTests")
+            path: "ios/Plugin")
     ]
 )

--- a/packages/authentication/Package.swift
+++ b/packages/authentication/Package.swift
@@ -49,11 +49,7 @@ let package = Package(
             swiftSettings: [
                 .define("RGCFA_INCLUDE_GOOGLE", .when(traits: ["Google"])),
                 .define("RGCFA_INCLUDE_FACEBOOK", .when(traits: ["Facebook"]))
-            ]),
-        .testTarget(
-            name: "FirebaseAuthenticationPluginTests",
-            dependencies: ["FirebaseAuthenticationPlugin"],
-            path: "ios/PluginTests")
+            ])
     ],
     swiftLanguageModes: [.v5]
 )

--- a/packages/crashlytics/Package.swift
+++ b/packages/crashlytics/Package.swift
@@ -22,10 +22,6 @@ let package = Package(
                 .product(name: "FirebaseCore", package: "firebase-ios-sdk"),
                 .product(name: "FirebaseCrashlytics", package: "firebase-ios-sdk")
             ],
-            path: "ios/Plugin"),
-        .testTarget(
-            name: "FirebaseCrashlyticsPluginTests",
-            dependencies: ["FirebaseCrashlyticsPlugin"],
-            path: "ios/PluginTests")
+            path: "ios/Plugin")
     ]
 )

--- a/packages/firestore/Package.swift
+++ b/packages/firestore/Package.swift
@@ -22,10 +22,6 @@ let package = Package(
                 .product(name: "FirebaseCore", package: "firebase-ios-sdk"),
                 .product(name: "FirebaseFirestore", package: "firebase-ios-sdk")
             ],
-            path: "ios/Plugin"),
-        .testTarget(
-            name: "FirebaseFirestorePluginTests",
-            dependencies: ["FirebaseFirestorePlugin"],
-            path: "ios/PluginTests")
+            path: "ios/Plugin")
     ]
 )

--- a/packages/functions/Package.swift
+++ b/packages/functions/Package.swift
@@ -22,10 +22,6 @@ let package = Package(
                 .product(name: "FirebaseCore", package: "firebase-ios-sdk"),
                 .product(name: "FirebaseFunctions", package: "firebase-ios-sdk")
             ],
-            path: "ios/Plugin"),
-        .testTarget(
-            name: "FirebaseFunctionsPluginTests",
-            dependencies: ["FirebaseFunctionsPlugin"],
-            path: "ios/PluginTests")
+            path: "ios/Plugin")
     ]
 )

--- a/packages/messaging/Package.swift
+++ b/packages/messaging/Package.swift
@@ -22,10 +22,6 @@ let package = Package(
                 .product(name: "FirebaseCore", package: "firebase-ios-sdk"),
                 .product(name: "FirebaseMessaging", package: "firebase-ios-sdk")
             ],
-            path: "ios/Plugin"),
-        .testTarget(
-            name: "FirebaseMessagingPluginTests",
-            dependencies: ["FirebaseMessagingPlugin"],
-            path: "ios/PluginTests")
+            path: "ios/Plugin")
     ]
 )

--- a/packages/performance/Package.swift
+++ b/packages/performance/Package.swift
@@ -22,10 +22,6 @@ let package = Package(
                 .product(name: "FirebaseCore", package: "firebase-ios-sdk"),
                 .product(name: "FirebasePerformance", package: "firebase-ios-sdk")
             ],
-            path: "ios/Plugin"),
-        .testTarget(
-            name: "FirebasePerformancePluginTests",
-            dependencies: ["FirebasePerformancePlugin"],
-            path: "ios/PluginTests")
+            path: "ios/Plugin")
     ]
 )

--- a/packages/remote-config/Package.swift
+++ b/packages/remote-config/Package.swift
@@ -22,10 +22,6 @@ let package = Package(
                 .product(name: "FirebaseCore", package: "firebase-ios-sdk"),
                 .product(name: "FirebaseRemoteConfig", package: "firebase-ios-sdk")
             ],
-            path: "ios/Plugin"),
-        .testTarget(
-            name: "FirebaseRemoteConfigPluginTests",
-            dependencies: ["FirebaseRemoteConfigPlugin"],
-            path: "ios/PluginTests")
+            path: "ios/Plugin")
     ]
 )

--- a/packages/storage/Package.swift
+++ b/packages/storage/Package.swift
@@ -22,10 +22,6 @@ let package = Package(
                 .product(name: "FirebaseCore", package: "firebase-ios-sdk"),
                 .product(name: "FirebaseStorage", package: "firebase-ios-sdk")
             ],
-            path: "ios/Plugin"),
-        .testTarget(
-            name: "FirebaseStoragePluginTests",
-            dependencies: ["FirebaseStoragePlugin"],
-            path: "ios/PluginTests")
+            path: "ios/Plugin")
     ]
 )


### PR DESCRIPTION
## Problem

`Package.swift` declares a test target at `ios/PluginTests`, but that path is not listed in the `files` array in `package.json`, so it is absent from the published npm tarball. SwiftPM validates the path of *every* declared target when it loads a manifest — including test targets it will never build — so resolution fails for anyone installing the plugin from npm into an SPM-based iOS project:

```
error: invalid custom path 'ios/PluginTests' for target 'FirebaseAuthenticationPluginTests'
```

In Xcode, File → Packages → Resolve Package Dependencies silently does nothing.

This affects all 11 packages in this repo.

## Fix

Remove the `.testTarget(...)` declaration from the affected manifests.

The test target was unusable regardless of packaging. The SPM target is named `<Name>Plugin` (e.g. `FirebaseAuthenticationPlugin`), while every test file does `@testable import Plugin` — the *Xcode project's* target name — so the target cannot compile even when built through Xcode against a simulator.

Shipping `ios/PluginTests/` instead would have made the manifest resolve, but it would distribute test sources no consumer needs — SwiftPM never builds a dependency's test targets — while keeping a target that still cannot compile.

`ios/PluginTests/` and the Xcode test targets are left in place. The tests continue to build and run through `Plugin.xcworkspace` exactly as before.

## Verification

- `swift package dump-package` passes for every package in the repo.
- Verified against a reconstructed tarball layout in the Capawesome plugins repo: `swift package describe` now succeeds where it previously failed with the error above.

Same fix as capawesome-team/capacitor-plugins#1022, applied to this repo.
