### PR TITLE
fix(android): sign in with Facebook via LoginManager instead of a hidden LoginButton

### DIFF
--- a/.changeset/lucky-pugs-listen.md
+++ b/.changeset/lucky-pugs-listen.md
@@ -1,0 +1,5 @@
+---
+"@capacitor-firebase/authentication": patch
+---
+
+fix(android): sign in with and link Facebook via `LoginManager` instead of a hidden `LoginButton`, whose click listener took a logout path and left the call unresolved whenever an access token was already cached

--- a/.changeset/proud-donkeys-wave.md
+++ b/.changeset/proud-donkeys-wave.md
@@ -1,0 +1,5 @@
+---
+"@capacitor-firebase/authentication": patch
+---
+
+fix(android): create the Facebook auth provider handler on first use so the Facebook SDK no longer blocks the main thread while the plugin loads

--- a/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthentication.java
+++ b/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthentication.java
@@ -64,8 +64,12 @@ public class FirebaseAuthentication {
     @Nullable
     private AppleAuthProviderHandler appleAuthProviderHandler;
 
+    // Written on the thread that makes the first Facebook call and read on the main thread in
+    // `handleOnActivityResult`, so the lazily created handler has to be published safely.
     @Nullable
-    private FacebookAuthProviderHandler facebookAuthProviderHandler;
+    private volatile FacebookAuthProviderHandler facebookAuthProviderHandler;
+
+    private boolean isFacebookProviderEnabled;
 
     @Nullable
     private GoogleAuthProviderHandler googleAuthProviderHandler;
@@ -302,11 +306,12 @@ public class FirebaseAuthentication {
     }
 
     public void linkWithFacebook(final PluginCall call) {
-        if (facebookAuthProviderHandler == null) {
+        FacebookAuthProviderHandler handler = getFacebookAuthProviderHandler();
+        if (handler == null) {
             call.reject(createProviderNotEnabledErrorMessage("Facebook"));
             return;
         }
-        facebookAuthProviderHandler.link(call);
+        handler.link(call);
     }
 
     public void linkWithGithub(final PluginCall call) {
@@ -509,11 +514,12 @@ public class FirebaseAuthentication {
     }
 
     public void signInWithFacebook(final PluginCall call) {
-        if (facebookAuthProviderHandler == null) {
+        FacebookAuthProviderHandler handler = getFacebookAuthProviderHandler();
+        if (handler == null) {
             call.reject(createProviderNotEnabledErrorMessage("Facebook"));
             return;
         }
-        facebookAuthProviderHandler.signIn(call);
+        handler.signIn(call);
     }
 
     public void signInWithGithub(final PluginCall call) {
@@ -589,8 +595,9 @@ public class FirebaseAuthentication {
         if (googleAuthProviderHandler != null) {
             googleAuthProviderHandler.signOut();
         }
-        if (facebookAuthProviderHandler != null) {
-            facebookAuthProviderHandler.signOut();
+        FacebookAuthProviderHandler facebookHandler = getFacebookAuthProviderHandler();
+        if (facebookHandler != null) {
+            facebookHandler.signOut();
         }
         if (playGamesAuthProviderHandler != null) {
             playGamesAuthProviderHandler.signOut();
@@ -954,14 +961,25 @@ public class FirebaseAuthentication {
         );
     }
 
+    @Nullable
+    private FacebookAuthProviderHandler getFacebookAuthProviderHandler() {
+        if (!isFacebookProviderEnabled) {
+            return null;
+        }
+        if (facebookAuthProviderHandler == null) {
+            facebookAuthProviderHandler = new FacebookAuthProviderHandler(this);
+        }
+        return facebookAuthProviderHandler;
+    }
+
     private void initAuthProviderHandlers(FirebaseAuthenticationConfig config) {
         List<String> providerList = Arrays.asList(config.getProviders());
         if (providerList.contains(ProviderId.APPLE)) {
             appleAuthProviderHandler = new AppleAuthProviderHandler(this);
         }
-        if (providerList.contains(ProviderId.FACEBOOK)) {
-            facebookAuthProviderHandler = new FacebookAuthProviderHandler(this);
-        }
+        // Creating the handler reads the Facebook SDK's shared preferences and queries the package
+        // manager, so it is deferred until the first Facebook call instead of blocking plugin load.
+        isFacebookProviderEnabled = providerList.contains(ProviderId.FACEBOOK);
         if (providerList.contains(ProviderId.GOOGLE)) {
             googleAuthProviderHandler = new GoogleAuthProviderHandler(this);
             googleAuthorizationResultLauncher = getPlugin()

--- a/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/handlers/FacebookAuthProviderHandler.java
+++ b/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/handlers/FacebookAuthProviderHandler.java
@@ -9,14 +9,14 @@ import com.facebook.FacebookCallback;
 import com.facebook.FacebookException;
 import com.facebook.login.LoginManager;
 import com.facebook.login.LoginResult;
-import com.facebook.login.widget.LoginButton;
 import com.getcapacitor.JSArray;
-import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.google.firebase.auth.AuthCredential;
 import com.google.firebase.auth.FacebookAuthProvider;
 import io.capawesome.capacitorjs.plugins.firebase.authentication.FirebaseAuthentication;
 import io.capawesome.capacitorjs.plugins.firebase.authentication.FirebaseAuthenticationPlugin;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.json.JSONException;
 
@@ -25,9 +25,9 @@ public class FacebookAuthProviderHandler {
     public static final int RC_FACEBOOK_AUTH = 0xface;
     public static final String ERROR_SIGN_IN_CANCELED = "Sign in canceled.";
     public static final String ERROR_LINK_CANCELED = "Link canceled.";
+    private static final List<String> DEFAULT_PERMISSIONS = Arrays.asList("email", "public_profile");
     private FirebaseAuthentication pluginImplementation;
     private CallbackManager mCallbackManager;
-    private LoginButton loginButton;
 
     @Nullable
     private PluginCall savedCall;
@@ -39,10 +39,7 @@ public class FacebookAuthProviderHandler {
         this.pluginImplementation = pluginImplementation;
         try {
             mCallbackManager = CallbackManager.Factory.create();
-            loginButton = new LoginButton(pluginImplementation.getPlugin().getContext());
-
-            loginButton.setPermissions("email", "public_profile");
-            loginButton.registerCallback(
+            LoginManager.getInstance().registerCallback(
                 mCallbackManager,
                 new FacebookCallback<LoginResult>() {
                     @Override
@@ -69,15 +66,13 @@ public class FacebookAuthProviderHandler {
     public void signIn(PluginCall call) {
         this.savedCall = call;
         this.isLink = false;
-        this.applySignInOptions(call, this.loginButton);
-        this.loginButton.performClick();
+        this.logIn(call);
     }
 
     public void link(PluginCall call) {
         this.savedCall = call;
         this.isLink = true;
-        this.applySignInOptions(call, this.loginButton);
-        this.loginButton.performClick();
+        this.logIn(call);
     }
 
     public void signOut() {
@@ -88,18 +83,29 @@ public class FacebookAuthProviderHandler {
         mCallbackManager.onActivityResult(requestCode, resultCode, data);
     }
 
-    private void applySignInOptions(final PluginCall call, LoginButton button) {
+    private void logIn(final PluginCall call) {
+        // The `loggerID` overload skips the warning that the two-argument one logs for activities
+        // with the AndroidX result APIs, which every Capacitor `BridgeActivity` is.
+        LoginManager.getInstance().logIn(pluginImplementation.getPlugin().getActivity(), getPermissions(call), null);
+    }
+
+    private List<String> getPermissions(final PluginCall call) {
+        List<String> permissions = new ArrayList<>(DEFAULT_PERMISSIONS);
         JSArray scopes = call.getArray("scopes");
-        if (scopes != null) {
-            try {
-                List<String> scopeList = scopes.toList();
-                scopeList.add("email");
-                scopeList.add("public_profile");
-                button.setPermissions(scopeList);
-            } catch (JSONException exception) {
-                Log.e(FirebaseAuthenticationPlugin.TAG, "applySignInOptions failed.", exception);
-            }
+        if (scopes == null) {
+            return permissions;
         }
+        try {
+            List<String> scopeList = scopes.toList();
+            for (String scope : scopeList) {
+                if (!permissions.contains(scope)) {
+                    permissions.add(scope);
+                }
+            }
+        } catch (JSONException exception) {
+            Log.e(FirebaseAuthenticationPlugin.TAG, "getPermissions failed.", exception);
+        }
+        return permissions;
     }
 
     private void handleSuccessCallback(LoginResult loginResult) {


### PR DESCRIPTION
Closes #1026

On Android, `FacebookAuthProviderHandler` builds a `LoginButton` — a `View` that is never attached to anything — purely so `signIn()` can call `performClick()` on it. ANR reports from our app show the main thread inside that constructor during `MainActivity.onCreate`:

```
at android.widget.TextView.setCompoundDrawablesWithIntrinsicBounds
at com.facebook.FacebookButtonBase.parseCompoundDrawableAttributes
at com.facebook.login.widget.LoginButton.<init>
at io.capawesome.capacitorjs.plugins.firebase.authentication.handlers.FacebookAuthProviderHandler.<init>
at com.getcapacitor.Bridge.registerAllPlugins
at com.crazygames.crazygamesapp.MainActivity.onCreate
```

Constructing the button runs `FacebookButtonBase.configureButton`, which inflates its compound drawables and pulls in `LoginManager`'s SharedPreferences read, PackageManager query and Custom Tabs bind — all before the WebView starts loading.

This drives `LoginManager` directly instead, and creates the handler on the first Facebook call rather than in `initAuthProviderHandlers`, so the remaining SDK work leaves the plugin load path too. iOS already uses `LoginManager`.

### Why this is the same request

`LoginButton`'s click listener does not configure anything of its own — `LoginClickListener.performLogin()` resolves the manager through `getLoginManager()`, which writes exactly the defaults `LoginManager` already holds:

| property | `LoginButtonProperties` | `LoginManager` |
|---|---|---|
| `loginBehavior` | `NATIVE_WITH_FALLBACK` | `NATIVE_WITH_FALLBACK` |
| `defaultAudience` | `FRIENDS` | `FRIENDS` |
| `authType` | `DIALOG_REREQUEST_AUTH_TYPE` | `DIALOG_REREQUEST_AUTH_TYPE` |
| `loginTargetApp` | `FACEBOOK` | `FACEBOOK` |
| `shouldSkipAccountDeduplication` | `false` | `false` |
| `messengerPageId` | `null` | `null` |
| `resetMessengerState` | `false` | `false` |

Since the plugin only ever called `setPermissions` on the button, that write-back was a no-op. The `loggerID` overload is used because it is the one the button called, and because the two-argument one logs a "please upgrade to the AndroidX result APIs" warning for any `ActivityResultRegistryOwner` — which every Capacitor `BridgeActivity` is. `registerCallback` on the singleton is what `LoginButton.registerCallback` delegated to, and the request code is still `RequestCodeOffset.Login.toRequestCode()` = `0xface`, so `CallbackManager` and `handleOnActivityResult` line up unchanged.

The handler is published through a `volatile` field, since it is now created on the thread serving the plugin call and read on the main thread in `handleOnActivityResult`. `getFacebookAuthProviderHandler()` returns `null` when Facebook is not in `providers`, keeping the "provider not enabled" rejection, and `handleOnActivityResult` still reads the field directly so a stray activity result never constructs the handler.

### The bug this fixes

The button's click listener branches on the cached token:

```kotlin
if (AccessToken.isCurrentAccessTokenActive()) performLogout(context) else performLogin()
```

So sign-in worked only until the first token was cached. Measured on a Pixel 10 Pro (Android 17, `facebook-login` 18.2.3, native Facebook app installed), invoking `signInWithFacebook` identically in each state:

| build | cached access token | result |
|---|---|---|
| before | none | resolves, login activity starts |
| before | active | **pending forever**, no activity started (2 runs, 25s each) |
| after | none | resolves |
| after | active | resolves, login activity starts |

In the broken case nothing happens at all — no login UI, and no logout either (`com.facebook.loginManager.xml` and the token cache are untouched), the listener being `@AutoHandleExceptions` and the detached button clicked off the main thread. The call simply never settles.

### Permissions

`applySignInOptions` mutated the list returned by `call.getArray("scopes")` and appended `email`/`public_profile` unconditionally, so passing either of those requested it twice; and because permissions were stored on the button, a call without `scopes` inherited whatever the previous call had set. `getPermissions` now rebuilds them per call from the defaults, de-duplicated.

### Follow-up left out

`LoginManager.createLogInActivityResultContract` would be the modern replacement for the `onActivityResult` path, as `googleAuthorizationResultLauncher` already does for Google. That needs a launcher registered before the activity starts, so it is a larger change than this fix and would put work back on the load path.

## Pull request checklist

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/docs/contributing/pull-requests/).

Tested on the device above: sign-in with and without a cached token, repeat sign-in on a cached handler, and sign-out. The plugin's registration window in `Bridge.registerAllPlugins` drops from a median of 17 ms to 10 ms across 6 cold starts each; whole-app cold start is dominated by WebView startup and shows no measurable difference on this hardware, so the win is on the slower devices the ANRs came from.
