### PR TITLE
fix(android): start Facebook sign-in via LoginManager instead of a hidden LoginButton

### DIFF
--- a/.changeset/facebook-login-manager.md
+++ b/.changeset/facebook-login-manager.md
@@ -1,0 +1,5 @@
+---
+'@capacitor-firebase/authentication': patch
+---
+
+fix(android): start Facebook sign-in via `LoginManager` so it no longer hangs once an access token is cached and no longer blocks the main thread at plugin load

--- a/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthentication.java
+++ b/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthentication.java
@@ -701,12 +701,6 @@ public class FirebaseAuthentication {
         playGamesAuthProviderHandler.handleOnActivityResult(call, result, true);
     }
 
-    public void handleOnActivityResult(int requestCode, int resultCode, @NonNull Intent data) {
-        if (requestCode == FacebookAuthProviderHandler.RC_FACEBOOK_AUTH && facebookAuthProviderHandler != null) {
-            facebookAuthProviderHandler.handleOnActivityResult(requestCode, resultCode, data);
-        }
-    }
-
     public void signInWithCredential(
         @NonNull SignInOptions options,
         @NonNull AuthCredential credential,

--- a/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthenticationPlugin.java
+++ b/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/FirebaseAuthenticationPlugin.java
@@ -21,13 +21,12 @@ import io.capawesome.capacitorjs.plugins.firebase.authentication.classes.options
 import io.capawesome.capacitorjs.plugins.firebase.authentication.classes.options.RevokeAccessTokenOptions;
 import io.capawesome.capacitorjs.plugins.firebase.authentication.classes.options.SendEmailVerificationOptions;
 import io.capawesome.capacitorjs.plugins.firebase.authentication.classes.options.SendPasswordResetEmailOptions;
-import io.capawesome.capacitorjs.plugins.firebase.authentication.handlers.FacebookAuthProviderHandler;
 import io.capawesome.capacitorjs.plugins.firebase.authentication.interfaces.EmptyResultCallback;
 import io.capawesome.capacitorjs.plugins.firebase.authentication.interfaces.NonEmptyResultCallback;
 import io.capawesome.capacitorjs.plugins.firebase.authentication.interfaces.Result;
 import org.json.JSONObject;
 
-@CapacitorPlugin(name = "FirebaseAuthentication", requestCodes = { FacebookAuthProviderHandler.RC_FACEBOOK_AUTH })
+@CapacitorPlugin(name = "FirebaseAuthentication")
 public class FirebaseAuthenticationPlugin extends Plugin {
 
     public static final String TAG = "FirebaseAuthentication";
@@ -1034,15 +1033,6 @@ public class FirebaseAuthenticationPlugin extends Plugin {
             }
         };
         implementation.getIdToken(false, callback);
-    }
-
-    @Override
-    protected void handleOnActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
-        super.handleOnActivityResult(requestCode, resultCode, data);
-        if (data == null) {
-            return;
-        }
-        implementation.handleOnActivityResult(requestCode, resultCode, data);
     }
 
     @ActivityCallback

--- a/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/handlers/FacebookAuthProviderHandler.java
+++ b/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/handlers/FacebookAuthProviderHandler.java
@@ -50,12 +50,6 @@ public class FacebookAuthProviderHandler {
         LoginManager.getInstance().logOut();
     }
 
-    private void logIn(PluginCall call, boolean isLink) {
-        this.savedCall = call;
-        this.isLink = isLink;
-        getLoginManager().logIn(pluginImplementation.getPlugin().getActivity(), callbackManager, getPermissions(call), null);
-    }
-
     @NonNull
     private LoginManager getLoginManager() {
         if (loginManager == null) {
@@ -99,38 +93,54 @@ public class FacebookAuthProviderHandler {
         return permissions;
     }
 
+    private void handleCancelCallback() {
+        PluginCall call = takeSavedCall();
+        if (call == null) {
+            return;
+        }
+        if (isLink) {
+            pluginImplementation.handleFailedLink(call, ERROR_LINK_CANCELED, null);
+        } else {
+            pluginImplementation.handleFailedSignIn(call, ERROR_SIGN_IN_CANCELED, null);
+        }
+    }
+
+    private void handleErrorCallback(FacebookException exception) {
+        PluginCall call = takeSavedCall();
+        if (call == null) {
+            return;
+        }
+        if (isLink) {
+            pluginImplementation.handleFailedLink(call, null, exception);
+        } else {
+            pluginImplementation.handleFailedSignIn(call, null, exception);
+        }
+    }
+
     private void handleSuccessCallback(LoginResult loginResult) {
-        if (savedCall == null) {
+        PluginCall call = takeSavedCall();
+        if (call == null) {
             return;
         }
         String accessToken = loginResult.getAccessToken().getToken();
         AuthCredential credential = FacebookAuthProvider.getCredential(accessToken);
         if (isLink) {
-            pluginImplementation.handleSuccessfulLink(savedCall, credential, null, null, accessToken, null);
+            pluginImplementation.handleSuccessfulLink(call, credential, null, null, accessToken, null);
         } else {
-            pluginImplementation.handleSuccessfulSignIn(savedCall, credential, null, null, accessToken, null, null);
+            pluginImplementation.handleSuccessfulSignIn(call, credential, null, null, accessToken, null, null);
         }
     }
 
-    private void handleCancelCallback() {
-        if (savedCall == null) {
-            return;
-        }
-        if (isLink) {
-            pluginImplementation.handleFailedLink(savedCall, ERROR_LINK_CANCELED, null);
-        } else {
-            pluginImplementation.handleFailedSignIn(savedCall, ERROR_SIGN_IN_CANCELED, null);
-        }
+    private void logIn(PluginCall call, boolean isLink) {
+        this.savedCall = call;
+        this.isLink = isLink;
+        getLoginManager().logIn(pluginImplementation.getPlugin().getActivity(), callbackManager, getPermissions(call), null);
     }
 
-    private void handleErrorCallback(FacebookException exception) {
-        if (savedCall == null) {
-            return;
-        }
-        if (isLink) {
-            pluginImplementation.handleFailedLink(savedCall, null, exception);
-        } else {
-            pluginImplementation.handleFailedSignIn(savedCall, null, exception);
-        }
+    @Nullable
+    private PluginCall takeSavedCall() {
+        PluginCall call = savedCall;
+        savedCall = null;
+        return call;
     }
 }

--- a/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/handlers/FacebookAuthProviderHandler.java
+++ b/packages/authentication/android/src/main/java/io/capawesome/capacitorjs/plugins/firebase/authentication/handlers/FacebookAuthProviderHandler.java
@@ -1,52 +1,70 @@
 package io.capawesome.capacitorjs.plugins.firebase.authentication.handlers;
 
-import android.content.Intent;
 import android.util.Log;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import com.facebook.AccessToken;
 import com.facebook.CallbackManager;
 import com.facebook.FacebookCallback;
 import com.facebook.FacebookException;
 import com.facebook.login.LoginManager;
 import com.facebook.login.LoginResult;
-import com.facebook.login.widget.LoginButton;
 import com.getcapacitor.JSArray;
-import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.google.firebase.auth.AuthCredential;
 import com.google.firebase.auth.FacebookAuthProvider;
 import io.capawesome.capacitorjs.plugins.firebase.authentication.FirebaseAuthentication;
 import io.capawesome.capacitorjs.plugins.firebase.authentication.FirebaseAuthenticationPlugin;
+import java.util.ArrayList;
 import java.util.List;
 import org.json.JSONException;
 
 public class FacebookAuthProviderHandler {
 
-    public static final int RC_FACEBOOK_AUTH = 0xface;
     public static final String ERROR_SIGN_IN_CANCELED = "Sign in canceled.";
     public static final String ERROR_LINK_CANCELED = "Link canceled.";
-    private FirebaseAuthentication pluginImplementation;
-    private CallbackManager mCallbackManager;
-    private LoginButton loginButton;
+
+    private final FirebaseAuthentication pluginImplementation;
+    private final CallbackManager callbackManager = CallbackManager.Factory.create();
+
+    @Nullable
+    private LoginManager loginManager;
 
     @Nullable
     private PluginCall savedCall;
 
-    @Nullable
-    private Boolean isLink;
+    private boolean isLink;
 
     public FacebookAuthProviderHandler(FirebaseAuthentication pluginImplementation) {
         this.pluginImplementation = pluginImplementation;
-        try {
-            mCallbackManager = CallbackManager.Factory.create();
-            loginButton = new LoginButton(pluginImplementation.getPlugin().getContext());
+    }
 
-            loginButton.setPermissions("email", "public_profile");
-            loginButton.registerCallback(
-                mCallbackManager,
+    public void signIn(PluginCall call) {
+        logIn(call, false);
+    }
+
+    public void link(PluginCall call) {
+        logIn(call, true);
+    }
+
+    public void signOut() {
+        LoginManager.getInstance().logOut();
+    }
+
+    private void logIn(PluginCall call, boolean isLink) {
+        this.savedCall = call;
+        this.isLink = isLink;
+        getLoginManager().logIn(pluginImplementation.getPlugin().getActivity(), callbackManager, getPermissions(call), null);
+    }
+
+    @NonNull
+    private LoginManager getLoginManager() {
+        if (loginManager == null) {
+            loginManager = LoginManager.getInstance();
+            loginManager.registerCallback(
+                callbackManager,
                 new FacebookCallback<LoginResult>() {
                     @Override
-                    public void onSuccess(LoginResult loginResult) {
+                    public void onSuccess(@NonNull LoginResult loginResult) {
                         handleSuccessCallback(loginResult);
                     }
 
@@ -56,68 +74,46 @@ public class FacebookAuthProviderHandler {
                     }
 
                     @Override
-                    public void onError(FacebookException exception) {
+                    public void onError(@NonNull FacebookException exception) {
                         handleErrorCallback(exception);
                     }
                 }
             );
-        } catch (Exception exception) {
-            Log.e(FirebaseAuthenticationPlugin.TAG, "initialization failed.", exception);
         }
+        return loginManager;
     }
 
-    public void signIn(PluginCall call) {
-        this.savedCall = call;
-        this.isLink = false;
-        this.applySignInOptions(call, this.loginButton);
-        this.loginButton.performClick();
-    }
-
-    public void link(PluginCall call) {
-        this.savedCall = call;
-        this.isLink = true;
-        this.applySignInOptions(call, this.loginButton);
-        this.loginButton.performClick();
-    }
-
-    public void signOut() {
-        LoginManager.getInstance().logOut();
-    }
-
-    public void handleOnActivityResult(int requestCode, int resultCode, Intent data) {
-        mCallbackManager.onActivityResult(requestCode, resultCode, data);
-    }
-
-    private void applySignInOptions(final PluginCall call, LoginButton button) {
+    @NonNull
+    private List<String> getPermissions(PluginCall call) {
+        List<String> permissions = new ArrayList<>();
+        permissions.add("email");
+        permissions.add("public_profile");
         JSArray scopes = call.getArray("scopes");
         if (scopes != null) {
             try {
-                List<String> scopeList = scopes.toList();
-                scopeList.add("email");
-                scopeList.add("public_profile");
-                button.setPermissions(scopeList);
+                permissions.addAll(scopes.toList());
             } catch (JSONException exception) {
-                Log.e(FirebaseAuthenticationPlugin.TAG, "applySignInOptions failed.", exception);
+                Log.e(FirebaseAuthenticationPlugin.TAG, "getPermissions failed.", exception);
             }
         }
+        return permissions;
     }
 
     private void handleSuccessCallback(LoginResult loginResult) {
-        AccessToken accessToken = loginResult.getAccessToken();
-        String accessTokenString = accessToken.getToken();
-        AuthCredential credential = FacebookAuthProvider.getCredential(accessTokenString);
-        if (savedCall == null || isLink == null) {
+        if (savedCall == null) {
             return;
         }
+        String accessToken = loginResult.getAccessToken().getToken();
+        AuthCredential credential = FacebookAuthProvider.getCredential(accessToken);
         if (isLink) {
-            pluginImplementation.handleSuccessfulLink(savedCall, credential, null, null, accessTokenString, null);
+            pluginImplementation.handleSuccessfulLink(savedCall, credential, null, null, accessToken, null);
         } else {
-            pluginImplementation.handleSuccessfulSignIn(savedCall, credential, null, null, accessTokenString, null, null);
+            pluginImplementation.handleSuccessfulSignIn(savedCall, credential, null, null, accessToken, null, null);
         }
     }
 
     private void handleCancelCallback() {
-        if (savedCall == null || isLink == null) {
+        if (savedCall == null) {
             return;
         }
         if (isLink) {
@@ -128,7 +124,7 @@ public class FacebookAuthProviderHandler {
     }
 
     private void handleErrorCallback(FacebookException exception) {
-        if (savedCall == null || isLink == null) {
+        if (savedCall == null) {
             return;
         }
         if (isLink) {


### PR DESCRIPTION
Closes #1026
Closes #1025

## Problem

On Android, `signInWithFacebook()` and `linkWithFacebook()` never settled once a Facebook access token was cached. The handler built a detached `LoginButton` and called `performClick()` on it. The button's click listener logs out instead of logging in when a token is active, the exception thrown off the main thread was swallowed by the SDK, and the plugin call stayed pending forever.

Building the `LoginButton` during plugin load also inflated drawables and touched the Facebook SDK on the main thread inside `MainActivity.onCreate`, which showed up in ANR reports.

## Solution

- Start the login through `LoginManager.logIn(...)` using the SDK's AndroidX activity result overload, so the flow no longer depends on a `View`, works regardless of a cached token, and delivers the result through the result registry.
- Fetch `LoginManager` lazily on the first sign-in. Plugin load no longer touches the Facebook SDK beyond creating a `CallbackManager`, and an uninitialized SDK now surfaces as a rejected call instead of a crash.
- Remove the legacy `onActivityResult` plumbing (`RC_FACEBOOK_AUTH`, `requestCodes`, both `handleOnActivityResult` overrides), which Capacitor marks as deprecated.
- Rebuild the permission list per call, so a call without `scopes` no longer inherits the previous call's permissions.

Thanks to the author of #1025 for the detailed analysis of the root cause. This PR takes a different route by using the SDK's AndroidX result API, so the deprecated Capacitor request-code path can be removed as well.

## Pull request checklist

- [ ] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/docs/contributing/pull-requests/).
